### PR TITLE
Add information about Matomo analytics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ and we also have set a **mission** to:
 >We will enable a community powered directory where the online presence of every public organization is easily findable, queryable and trustworthy.
 
 We hope that will help you contribute meaningfully.
+To get an insight in how the website is already being used, see our [Matomo analytics](https://matomo.wikimedia.se/index.php?module=CoreHome&idSite=7).
 As a more detailed help, and to see what we already have planned, checkout our [roadmap](https://github.com/orgs/govdirectory/projects/2) and [milestones](https://github.com/govdirectory/website/milestones).
 
 ## Problems, suggestions and questions in issues

--- a/README.md
+++ b/README.md
@@ -29,18 +29,24 @@ To learn more about Snowman and its concepts [check out its readme](https://gith
 
 Not usable yet, since we're still in a concept phase.
 
-## Unlock accelerator program
-
-This project has been accepted in the [Unlock accelerator program](https://www.wikimedia.de/unlock/) program ([original application](https://www.wikidata.org/wiki/User:Ainali/Social_media_for_public_organizations/Unlock)).
-
-During the accelerator, which ends in October, we have defined a Minimale Vialble Prodcut (MVP) to: "As an MVP we want to create a working website where people can search, filter and add data about Swedish and British public institutions and their social media accounts."
-
 ## Maintainers
 
 * [Abbe98](https://github.com/Abbe98)
 * [Ainali](https://github.com/Ainali)
 
 Besides pinging us in [issues](https://github.com/govdirectory/website/issues), [pull requests](https://github.com/govdirectory/website/pulls) and [discussions](https://github.com/govdirectory/website/discussions), you can also reach us on Twitter where we are [@Jan_Ainali](https://twitter.com/Jan_Ainali/) and [@AlbinPCLarsson](https://twitter.com/AlbinPCLarsson).
+
+## Acknowledgements
+
+### Unlock accelerator program
+
+This project has been accepted in the [Unlock accelerator program](https://www.wikimedia.de/unlock/) program ([original application](https://www.wikidata.org/wiki/User:Ainali/Social_media_for_public_organizations/Unlock)).
+
+During the accelerator, which ends in October, we have defined a Minimale Vialble Prodcut (MVP) to: "As an MVP we want to create a working website where people can search, filter and add data about Swedish and British public institutions and their social media accounts."
+
+### Matomo server
+
+[Wikimedia Sverige](https://github.com/Wikimedia-Sverige) is graciously providing us with Matomo analytics. [The dashboard](https://matomo.wikimedia.se/index.php?module=CoreHome&idSite=7) has been made publicly accessible.
 
 ## Contributing
 


### PR DESCRIPTION
- Sections reshuffled on README to put both Unlock and Matomo under Acknowledgements.
- Matomo link added in CONTRIBUTING for extra insights.