### PR TITLE
🎟 add a footer link to the events page

### DIFF
--- a/templates/layouts/layout.html
+++ b/templates/layouts/layout.html
@@ -75,6 +75,8 @@
                     <li><a class="no-decoration" href="https://github.com/govdirectory">Github</a></li>
 
                     <li><a class="no-decoration" href="https://www.wikidata.org/wiki/Wikidata:Gov_Directory">Improve the data</a></li>
+                    
+                    <li><a class="no-decoration" href="https://www.wikidata.org/wiki/Wikidata:WikiProject_Govdirectory/Events">Events</a></li>
 
                 </ul>
             </div>


### PR DESCRIPTION
As the events could be of general interest not only for people familiar with Wikidata.