### PR TITLE
Fix link that redirects

### DIFF
--- a/templates/layouts/layout.html
+++ b/templates/layouts/layout.html
@@ -73,7 +73,7 @@
                 <ul class="list-unstyled">
                     <li><a class="no-decoration" href="https://github.com/govdirectory">Github</a></li>
 
-                    <li><a class="no-decoration" href="https://www.wikidata.org/wiki/Wikidata:Gov_Directory">Improve the data</a></li>
+                    <li><a class="no-decoration" href="https://www.wikidata.org/wiki/Wikidata:WikiProject_Govdirectory">Improve the data</a></li>
 
                     <li><a class="no-decoration" href="https://www.wikidata.org/wiki/Wikidata:WikiProject_Govdirectory/Events">Events</a></li>
                 </ul>


### PR DESCRIPTION
Wikidata:Gov_Directory -> Wikidata:WikiProject_Govdirectory