### PR TITLE
Adding Scottish executive agencies

### DIFF
--- a/queries/countries.rq
+++ b/queries/countries.rq
@@ -11,7 +11,7 @@ SELECT
 WHERE {
   VALUES (?uri ?name ?safeName ?description) {
     (wd:Q34 'Sweden' 'sweden' 'All Swedish government agencies are included.')
-    (wd:Q145 'United Kingdom' 'united-kingdom' 'Current content includes ministerial departments and Scottish local authorities, NHS boards, and Health and social care partnerships.')
+    (wd:Q145 'United Kingdom' 'united-kingdom' 'Current content includes ministerial departments and Scottish exceutive agencies, local authorities, NHS boards, and Health and social care partnerships.')
     (wd:Q223 'Greenland' 'greenland' 'Current content only includes municipalities.')
     (wd:Q35 'Denmark' 'denmark' 'Current content only includes municipalities and regions.')
     (wd:Q20 'Norway' 'norway' 'Current content only includes municipalities, ministries and embassies.')

--- a/queries/generators/united-kingdom.rq
+++ b/queries/generators/united-kingdom.rq
@@ -1,4 +1,4 @@
-# expected_result_count: 100
+# expected_result_count: 109
 SELECT DISTINCT
   ?qid
   ?orgLabel
@@ -12,9 +12,10 @@ WHERE {
 
   VALUES ?type {
     wd:Q2500378 # department of the United Kingdom Government (23)
-    wd:Q21451686 # local authorities (32)
-    wd:Q83425186 # NHS boards (14)
-    wd:Q20667323 # Health and social care partnerships (31)
+    wd:Q21451686 # Scottish local authorities (32)
+    wd:Q83425186 # Scottish NHS boards (14)
+    wd:Q20667323 # Scottish Health and social care partnerships (31)
+    wd:Q108838260 # Scottish executive agencies (9)
   }
 
   ?org wdt:P31 ?type .
@@ -32,4 +33,4 @@ WHERE {
 
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en" }
 }
-ORDER BY DESC(?type)
+ORDER BY ?type ?orgLabel


### PR DESCRIPTION
Changing sort order as well to type and orgLabel, putting the executive agencies on the top.