### PR TITLE
Add more Scottish agencies

### DIFF
--- a/queries/countries.rq
+++ b/queries/countries.rq
@@ -11,7 +11,7 @@ SELECT
 WHERE {
   VALUES (?uri ?name ?safeName ?description) {
     (wd:Q34 'Sweden' 'sweden' 'All Swedish government agencies are included.')
-    (wd:Q145 'United Kingdom' 'united-kingdom' 'Current content includes ministerial departments and Scottish exceutive agencies, local authorities, NHS boards, NDPBs, courts, public corporations, commisioners, ombudsmen and Health and social care partnerships.')
+    (wd:Q145 'United Kingdom' 'united-kingdom' 'Current content includes ministerial departments and Scottish exceutive agencies, local authorities, NHS boards, NDPBs, courts, public corporations, tribunals, parole boards, Queen's printer, non-ministerial government departments, commissioners, ombudsmen and Health and social care partnerships.')
     (wd:Q223 'Greenland' 'greenland' 'Current content only includes municipalities.')
     (wd:Q35 'Denmark' 'denmark' 'Current content only includes municipalities and regions.')
     (wd:Q20 'Norway' 'norway' 'Current content only includes municipalities, ministries and embassies.')

--- a/queries/generators/united-kingdom.rq
+++ b/queries/generators/united-kingdom.rq
@@ -1,4 +1,4 @@
-# expected_result_count: 223
+# expected_result_count: 237
 SELECT DISTINCT
   ?qid
   ?orgLabel
@@ -26,10 +26,16 @@ WHERE {
 		VALUES ?type {
 			wd:Q3343298  # NDPBs (45)
 			wd:Q55657615 wd:Q524778 wd:Q169180 # commissioners and ombudsmen (7)
+            wd:Q3044788 # non-ministerial government departments (2)
+            wd:Q7139410 # parole board (1)
+            wd:Q1412224 # tribunal (10)
+            wd:Q16931297 # Queen's printer (1)
 		}
 		?org wdt:P31 ?type ;
-	        wdt:P1001 wd:Q22 .
+	       wdt:P1001 wd:Q22 .
 		MINUS { ?org wdt:P31 wd:Q5532360 }
+        MINUS { ?org wdt:P1001 wd:Q1156248 }
+        MINUS { ?org p:P1001 ?js. ?js pq:P582 [] }
 	}
 	UNION
 	{ # Scottish courts (56)


### PR DESCRIPTION
Tribunals, parole board, Queen's printer and  non-ministerial government departments