### PR TITLE
Fixed the first level units of East Timor

### DIFF
--- a/queries/countries.rq
+++ b/queries/countries.rq
@@ -23,7 +23,7 @@ WHERE {
     (wd:Q33 'Finland' 'finland' 'Current content includes regions.')
     (wd:Q212 'Ukraine' 'ukraine' 'Current content includes ministries and first level administrative units.')
     (wd:Q159 'Russia' 'russia' 'Current content includes the government and ministries.')
-    (wd:Q574 'East Timor' 'east-timor' 'Current content includes ministries, municipalities, administrative posts and sucos.')
+    (wd:Q574 'East Timor' 'east-timor' 'Current content includes ministries, municipalities, special administrative region, administrative posts and sucos.')
   }
 
   OPTIONAL {

--- a/queries/generators/east-timor.rq
+++ b/queries/generators/east-timor.rq
@@ -11,7 +11,8 @@ WHERE {
 
   VALUES ?type {
     wd:Q110813527 # ministries (20)
-    wd:Q741821 # municipalities (14)
+    wd:Q741821 # municipalities (13)
+    wd:Q111127635 # special administrative region (1)
     wd:Q1512109 # administrative posts (67)
     wd:Q22044663  # sucos (452)
   }


### PR DESCRIPTION
The municipalities and the special administrative unit are different types and now uses different items.