### PR TITLE
Adding Dutch waterboards and the Kings cabinet

### DIFF
--- a/queries/countries.rq
+++ b/queries/countries.rq
@@ -18,7 +18,7 @@ WHERE {
     (wd:Q117 'Ghana' 'ghana' 'Current content only includes regions and districts.')
     (wd:Q183 'Germany' 'germany' 'Current content only includes ministries, federated states and governmental districts.')
     (wd:Q258 'South Africa' 'south-africa' 'Current content includes departments, independent constitutional bodies, provinces and municipalities.')
-    (wd:Q55 'Netherlands' 'netherlands' 'Current content includes ministries, courts, provincies and municipalities.')
+    (wd:Q55 'Netherlands' 'netherlands' 'Current content includes ministries, courts, water boards, the King's cabinet, provincies and municipalities.')
     (wd:Q664 'New Zealand' 'new-zealand' 'Current content includes district health boards, wānangas, state-owned enterprises, regional councils and territorial authorities.')
     (wd:Q33 'Finland' 'finland' 'Current content includes regions.')
     (wd:Q212 'Ukraine' 'ukraine' 'Current content includes ministries and first level administrative units.')

--- a/queries/generators/netherlands.rq
+++ b/queries/generators/netherlands.rq
@@ -1,4 +1,4 @@
-# expected_result_count: 389
+# expected_result_count: 411
 SELECT DISTINCT
   ?qid
   ?orgLabel
@@ -9,18 +9,29 @@ SELECT DISTINCT
 WHERE {
   BIND(wd:Q55 AS ?country)
 
+  {
+  # agencies with country set to the Netherlands
   VALUES ?type {
-    wd:Q3143387 # Ministries (12)
-    wd:Q4500821 # Appeals court (4)
-    wd:Q190752  # Supreme court (2)
-    wd:Q2125157 # District court (11)
-    wd:Q134390  # Provinces (12)
-    wd:Q2039348 # Municipalities (345)
-    wd:Q26934845 # Integral overseas territory (3)
+    wd:Q3143387 # ministries (12)
+    wd:Q4500821 # appeals court (4)
+    wd:Q190752  # supreme court (2)
+    wd:Q2125157 # district court (11)
+    wd:Q134390  # provinces (12)
+    wd:Q702081 # water boards (21)
+    wd:Q2039348 # municipalities (345)
+    wd:Q26934845 # integral overseas territory (3)
   }
   ?org wdt:P31 ?type .
 
   ?org wdt:P17 ?country .
+  } UNION {
+    # special case without a unique type
+    VALUES ?org {
+      wd:Q1857094 # cabinet of the King (1)
+    }
+
+    BIND("cabinet of the King" AS ?typeLabel)
+  }
 
   MINUS { ?org wdt:P576 [] }
   MINUS { ?org wdt:P1366 [] }


### PR DESCRIPTION
The King's cabinet is one of a kind, so using the same solution as for the Swedish Domstolsverket.