### PR TITLE
Ghana has one new district and is expected to total 277

### DIFF
--- a/queries/generators/ghana.rq
+++ b/queries/generators/ghana.rq
@@ -1,3 +1,4 @@
+# expected_result_count: 277
 SELECT DISTINCT
   ?qid
   ?orgLabel
@@ -10,7 +11,7 @@ WHERE {
   BIND(wd:Q117 AS ?country)
 
   VALUES ?type {
-    wd:Q545769 # district of Ghana (260)
+    wd:Q545769 # district of Ghana (261)
     wd:Q1052743 # region of Ghana (16)
   }
 


### PR DESCRIPTION
Updated documentation on expected results