### PR TITLE
Restores behavior of wikidata buttons

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -442,6 +442,7 @@ header.topic {
     width: 18px;
     height: 18px;
     padding: 8px;
+    box-sizing: content-box;
 }
 
 /* STATISTICS */


### PR DESCRIPTION
The border-box on the other buttons was unintentionally inherited to these. Set these explicitly to content-box instead.