### PR TITLE
Concise text (as tsv) to download

### DIFF
--- a/templates/country-page.html
+++ b/templates/country-page.html
@@ -54,7 +54,7 @@
 										<h2 class="m0 expand-mobile">Agencies</h2>
 										<input id="filter-input" type="text" placeholder="Search" aria-label="Search/filter table" class="need-js expand-mobile"/>
 								</div>
-								<a id="download" download="{{ .name }}.tsv" href="#" class="btn need-js expand-mobile">Download (as tsv)</a>
+								<a id="download" download="{{ .name }}.tsv" href="#" class="btn need-js expand-mobile">Download (as TSV)</a>
 						</div>
 				</div>
     </section>

--- a/templates/country-page.html
+++ b/templates/country-page.html
@@ -54,7 +54,7 @@
 										<h2 class="m0 expand-mobile">Agencies</h2>
 										<input id="filter-input" type="text" placeholder="Search" aria-label="Search/filter table" class="need-js expand-mobile"/>
 								</div>
-								<a id="download" download="{{ .name }}.tsv" href="#" class="btn need-js expand-mobile">Download</a>
+								<a id="download" download="{{ .name }}.tsv" href="#" class="btn need-js expand-mobile">Download (as tsv)</a>
 						</div>
 				</div>
     </section>

--- a/templates/org.html
+++ b/templates/org.html
@@ -117,7 +117,7 @@
         <div class="container move-away">
             <h2 class="m0">Platforms and accounts</h2>
             {{- if $socialAccounts -}}
-            <a id="download" download="{{ .orgLabel }} - {{ .qid }}.tsv" href="#" class="btn need-js">Download (as tsv)</a>
+            <a id="download" download="{{ .orgLabel }} - {{ .qid }}.tsv" href="#" class="btn need-js">Download (as TSV)</a>
             {{- end -}}
         </div>
     </section>

--- a/templates/org.html
+++ b/templates/org.html
@@ -117,7 +117,7 @@
         <div class="container move-away">
             <h2 class="m0">Platforms and accounts</h2>
             {{- if $socialAccounts -}}
-            <a id="download" download="{{ .orgLabel }} - {{ .qid }}.tsv" href="#" class="btn need-js">Download</a>
+            <a id="download" download="{{ .orgLabel }} - {{ .qid }}.tsv" href="#" class="btn need-js">Download (as tsv)</a>
             {{- end -}}
         </div>
     </section>

--- a/templates/topic-page.html
+++ b/templates/topic-page.html
@@ -20,7 +20,7 @@
 										<h2 class="m0 expand-mobile">Agencies</h2>
 										<input id="filter-input" type="text" placeholder="Search" aria-label="Search/filter table" class="need-js expand-mobile"/>
 								</div>
-								<a id="download" download="{{ .name }}.tsv" href="#" class="btn need-js expand-mobile">Download (as tsv)</a>
+								<a id="download" download="{{ .name }}.tsv" href="#" class="btn need-js expand-mobile">Download (as TSV)</a>
 						</div>
         </div>
     </section>

--- a/templates/topic-page.html
+++ b/templates/topic-page.html
@@ -20,7 +20,7 @@
 										<h2 class="m0 expand-mobile">Agencies</h2>
 										<input id="filter-input" type="text" placeholder="Search" aria-label="Search/filter table" class="need-js expand-mobile"/>
 								</div>
-								<a id="download" download="{{ .name }}.tsv" href="#" class="btn need-js expand-mobile">Download</a>
+								<a id="download" download="{{ .name }}.tsv" href="#" class="btn need-js expand-mobile">Download (as tsv)</a>
 						</div>
         </div>
     </section>


### PR DESCRIPTION
Fix for #145 
Considering space - kept it at (as tsv) suffix to the Download so it is intuitive to the user. 