### PR TITLE
Inactive accounts query

### DIFF
--- a/queries/account-data.rq
+++ b/queries/account-data.rq
@@ -17,7 +17,7 @@ WHERE {
   ?statement ?propValuePredicate ?value .
 
   OPTIONAL { ?statement pq:P1552 ?quality }
-
+  MINUS { ?statement pq:P582 [] }
   BIND(IF(BOUND(?quality), IF(?quality = wd:Q28378282, True, False), False) AS ?verified)
 
   BIND(IRI(REPLACE(?formatter, '\\$1', ?value)) AS ?url)

--- a/templates/country-page.html
+++ b/templates/country-page.html
@@ -54,7 +54,7 @@
 										<h2 class="m0 expand-mobile">Agencies</h2>
 										<input id="filter-input" type="text" placeholder="Search" aria-label="Search/filter table" class="need-js expand-mobile"/>
 								</div>
-								<a id="download" download="{{ .name }}.tsv" href="#" class="btn need-js expand-mobile">Download (as tsv)</a>
+								<a id="download" download="{{ .name }}.tsv" href="#" class="btn need-js expand-mobile">Download (as TSV)</a>
 						</div>
 				</div>
     </section>

--- a/templates/country-page.html
+++ b/templates/country-page.html
@@ -54,7 +54,7 @@
 										<h2 class="m0 expand-mobile">Agencies</h2>
 										<input id="filter-input" type="text" placeholder="Search" aria-label="Search/filter table" class="need-js expand-mobile"/>
 								</div>
-								<a id="download" download="{{ .name }}.tsv" href="#" class="btn need-js expand-mobile">Download</a>
+								<a id="download" download="{{ .name }}.tsv" href="#" class="btn need-js expand-mobile">Download (as tsv)</a>
 						</div>
 				</div>
     </section>

--- a/templates/org.html
+++ b/templates/org.html
@@ -117,7 +117,7 @@
         <div class="container move-away">
             <h2 class="m0">Platforms and accounts</h2>
             {{- if $socialAccounts -}}
-            <a id="download" download="{{ .orgLabel }} - {{ .qid }}.tsv" href="#" class="btn need-js">Download (as tsv)</a>
+            <a id="download" download="{{ .orgLabel }} - {{ .qid }}.tsv" href="#" class="btn need-js">Download (as TSV)</a>
             {{- end -}}
         </div>
     </section>

--- a/templates/org.html
+++ b/templates/org.html
@@ -117,7 +117,7 @@
         <div class="container move-away">
             <h2 class="m0">Platforms and accounts</h2>
             {{- if $socialAccounts -}}
-            <a id="download" download="{{ .orgLabel }} - {{ .qid }}.tsv" href="#" class="btn need-js">Download</a>
+            <a id="download" download="{{ .orgLabel }} - {{ .qid }}.tsv" href="#" class="btn need-js">Download (as tsv)</a>
             {{- end -}}
         </div>
     </section>

--- a/templates/topic-page.html
+++ b/templates/topic-page.html
@@ -20,7 +20,7 @@
 										<h2 class="m0 expand-mobile">Agencies</h2>
 										<input id="filter-input" type="text" placeholder="Search" aria-label="Search/filter table" class="need-js expand-mobile"/>
 								</div>
-								<a id="download" download="{{ .name }}.tsv" href="#" class="btn need-js expand-mobile">Download (as tsv)</a>
+								<a id="download" download="{{ .name }}.tsv" href="#" class="btn need-js expand-mobile">Download (as TSV)</a>
 						</div>
         </div>
     </section>

--- a/templates/topic-page.html
+++ b/templates/topic-page.html
@@ -20,7 +20,7 @@
 										<h2 class="m0 expand-mobile">Agencies</h2>
 										<input id="filter-input" type="text" placeholder="Search" aria-label="Search/filter table" class="need-js expand-mobile"/>
 								</div>
-								<a id="download" download="{{ .name }}.tsv" href="#" class="btn need-js expand-mobile">Download</a>
+								<a id="download" download="{{ .name }}.tsv" href="#" class="btn need-js expand-mobile">Download (as tsv)</a>
 						</div>
         </div>
     </section>


### PR DESCRIPTION
Why?
Fixes #83 

Details
Adds a condition to exclude online accounts that have an end date set so only active ones are returned in the query

Test
Manually tested the query in Wikidata Query Service specifically using Swedish Authority as an example

Pre Query Change Results
![prequerychange](https://user-images.githubusercontent.com/7208041/193541505-51a91d63-d8cc-4cbf-93d1-2d042b141432.png)

Post Query Change Results
![postQueryChange](https://user-images.githubusercontent.com/7208041/193541575-93e20a0e-ed49-48bd-b47e-67a64a1cca8a.png)


