### PR TITLE
Exclude end dated accounts from the query

### DIFF
--- a/queries/account-data.rq
+++ b/queries/account-data.rq
@@ -17,7 +17,7 @@ WHERE {
   ?statement ?propValuePredicate ?value .
 
   OPTIONAL { ?statement pq:P1552 ?quality }
-
+  MINUS { ?statement pq:P582 [] }
   BIND(IF(BOUND(?quality), IF(?quality = wd:Q28378282, True, False), False) AS ?verified)
 
   BIND(IRI(REPLACE(?formatter, '\\$1', ?value)) AS ?url)


### PR DESCRIPTION
Why?
Fixes https://github.com/govdirectory/website/issues/83

Details
Adds a condition to exclude online accounts that have an end date set so only active ones are returned in the query

Test
Manually tested the query in Wikidata Query Service specifically using Swedish Authority as an example

Pre Query Change Results
![prequerychange](https://user-images.githubusercontent.com/7208041/193641714-f63ce6d4-135d-4713-9357-5d3deae13a3f.png)

Post Query Change Results
![postQueryChange](https://user-images.githubusercontent.com/7208041/193641684-47e9491b-3099-4f98-8fcb-64faa5e68b33.png)
