### PR TITLE
Explain abbreviations

### DIFF
--- a/ADD_A_COUNTRY.md
+++ b/ADD_A_COUNTRY.md
@@ -84,7 +84,7 @@ The section above illustrates which variables are expected by Govdirectory, one 
   BIND(wd:Q34 AS ?country)
 ```
 
-This line connects the query to a country in Wikidata, it's used to connect this query to the country configuration. Update the Q-identifier.
+This line connects the query to a country in Wikidata, it's used to connect this query to the country configuration. Update the Wikidata identifier (Q-id).
 
 ```sparql
   VALUES ?type {

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ The goal is for this directory to be useful to journalists, web-archivists, rese
 
 ## Development setup
 
-Govdirectory is a static site meaning that it already has all of its pages generated when a visitor visits it. Govdirectory uses Snowman and SPARQL to do this.
+Govdirectory is a static site meaning that it already has all of its pages generated when a visitor visits it. Govdirectory uses Snowman and [SPARQL](https://www.w3.org/TR/sparql11-query/) to do this.
 
-Because each initial build of Snowman issues thousands (yes thousands) of SPARQL queries one should never make an **initial** build against `query.wikidata.org` but rather against a local WDQS instance. However, because setting up a WDQS instance is nontrival we provide a copy of a [Snowman build cache directory](https://github.com/govdirectory/website-cache). If in use, this will ensure Snowman only queries Wikidata when a query is updated.
+Because each initial build of Snowman issues thousands (yes thousands) of SPARQL queries one should never make an **initial** build against `query.wikidata.org` but rather against a local Wikidata Query Service (WDQS) instance. However, because setting up a WDQS instance is nontrival we provide a copy of a [Snowman build cache directory](https://github.com/govdirectory/website-cache). If in use, this will ensure Snowman only queries Wikidata when a query is updated.
 
 ### Prerequisites
 
  - [Git](https://git-scm.com/)
  - [Snowman](https://github.com/glaciers-in-archives/snowman)
- - **Optinally**: A local Wikidata Query Service (WDQS) instance 
+ - **Optionally**: A local WDQS instance 
 
 1\. Clone the project:
 ```shell

--- a/templates/standard-for-public-code.html
+++ b/templates/standard-for-public-code.html
@@ -814,7 +814,7 @@ Including examples that make users want to immediately start using the codebase 
 
 <h2><a href="https://standard.publiccode.net/criteria/use-plain-english.html" class="dark-link">Use plain English</a></h2>
 
-&#9744;<!-- &#9745; --> criterion met.
+&#9745;<!-- &#9745; --> criterion met.
 
 <table id="use-plain-english" style="width:100%">
 <tr><th class="js-sort-none">Meets</th><th class="js-sort-none">Requirement</th><th class="js-sort-none" style="width:25%">Notes and links</th></tr>
@@ -868,13 +868,13 @@ Any translation MUST be up to date with the English version and vice versa.
 
 <tr>
 <td>
-
+Ok
 </td>
 <td>
 There SHOULD be no acronyms, abbreviations, puns or legal/non-English/domain specific terms in the codebase without an explanation preceding it or a link to an explanation.
 </td>
 <td>
-Some acronyms used, need to be checked.
+
 </td>
 </tr>
 


### PR DESCRIPTION
Some polish in language and link to reference for SPARQL.

Now meets abbreviation requirement in Use plain English in Standard for Public Code and thus the entire criteria.