### PR TITLE
Add list of standards to follow to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,18 @@ Document choices or decisions you make in the commit message, this will enable e
 If you are adding code, make sure you've added and updated the relevant documentation and tests before you submit your pull request.
 Make sure to write tests that show the behavior of the newly added or changed code.
 
+#### Standards to follow
+
+These are the standards that Govdirectory uses.
+Please make sure that your contributions are aligned with them so that they can be merged more easily.
+
+* [Web Content Accessibility Guidelines 2.2](https://www.w3.org/TR/WCAG22/)
+* [Standard Readme](https://github.com/RichardLitt/standard-readme/blob/main/spec.md) (applicable for the README file only)
+* [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) extended format for dates (e.g. 2023-09-17)
+
 For icons, we are using the libraries [Maki](https://labs.mapbox.com/maki-icons/) and [Temaki](https://ideditor.github.io/temaki/docs/) for a consistent style. If you can't find a usable icon in those sets, try to emulate their style or find other icons similar to it.
+
+While we haven't committed to be fully compliant with the [Standard for Public Code](https://standard.publiccode.net) we would appreciate if contributions brings Govdirectory closer to meeting it rather than make it deviate further.
 
 ### 2. Pull request
 

--- a/templates/standard-for-public-code.html
+++ b/templates/standard-for-public-code.html
@@ -906,7 +906,7 @@ Providing a translation of any code, documentation or tests is OPTIONAL.
 
 <h2><a href="https://standard.publiccode.net/criteria/use-open-standards.html" class="dark-link">Use open standards</a></h2>
 
-&#9744;<!-- &#9745; --> criterion met.
+&#9745;<!-- &#9745; --> criterion met.
 
 <table id="use-open-standards" style="width:100%">
 <tr><th class="js-sort-none">Meets</th><th class="js-sort-none">Requirement</th><th class="js-sort-none" style="width:25%">Notes and links</th></tr>
@@ -936,13 +936,13 @@ Any non-open standards used MUST be recorded clearly as such in the documentatio
 
 <tr>
 <td>
-
+Ok
 </td>
 <td>
 Any standard chosen for use within the codebase MUST be listed in the documentation with a link to where it is available.
 </td>
 <td>
-
+<a href="https://github.com/govdirectory/website/blob/main/CONTRIBUTING.md#standards-to-follow">CONTRIBUTING</a>
 </td>
 </tr>
 
@@ -957,7 +957,7 @@ Any non-open standards chosen for use within the codebase MUST NOT hinder collab
 
 </td>
 </tr>
-
+N/A
 <tr>
 <td>
 
@@ -1376,13 +1376,13 @@ The style guide SHOULD include expectations for inline comments and documentatio
 
 <tr>
 <td>
-
+Ok
 </td>
 <td>
 Including expectations for <a href="https://standard.publiccode.net/criteria/use-plain-english.html">understandable English</a> in the style guide is OPTIONAL.
 </td>
 <td>
-
+<a href="https://github.com/govdirectory/website/blob/main/CONTRIBUTING.md#standards-to-follow">CONTRIBUTING</a>
 </td>
 </tr>
 


### PR DESCRIPTION
Besides the list, also check that no non-open standards are used, thus meets the entire Open standards criteria of Standard for Public Code.

The list also makes us meet one requirement in style.