### PR TITLE
Update maintainers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ Intended to be used through the website at [govdirectory.org](https://govdirecto
 * [Abbe98](https://github.com/Abbe98)
 * [Ainali](https://github.com/Ainali)
 
-Besides pinging us in [issues](https://github.com/govdirectory/website/issues), [pull requests](https://github.com/govdirectory/website/pulls) and [discussions](https://github.com/govdirectory/website/discussions), you can also reach us on Twitter where we are [@Jan_Ainali](https://twitter.com/Jan_Ainali/) and [@AlbinPCLarsson](https://twitter.com/AlbinPCLarsson).
+For now, the maintainers have the final say in all matters, but we are taking all opinions from contributors into consideration.
+When the community grows, we are planning to shift to a governance model with shared responsibilities.
+Besides pinging us in [issues](https://github.com/govdirectory/website/issues), [pull requests](https://github.com/govdirectory/website/pulls) and [discussions](https://github.com/govdirectory/website/discussions), you can also reach us on Mastodon where we are [@ainali](https://social.coop/@ainali) and [@abbe98](https://mastodon.social/@abbe98).
 
 ## Acknowledgements
 

--- a/templates/standard-for-public-code.html
+++ b/templates/standard-for-public-code.html
@@ -262,7 +262,7 @@ While Wikidata is primary, queries could be made to another Wikibase with replic
 
 <h2><a href="https://standard.publiccode.net/criteria/welcome-contributors.html" class="dark-link">Welcome contributors</a></h2>
 
-&#9744;<!-- &#9745; --> criterion met.
+&#9745;<!-- &#9745; --> criterion met.
 
 <table id="welcome-contributors" style="width:100%">
 <tr><th class="js-sort-none">Meets</th><th class="js-sort-none">Requirement</th><th class="js-sort-none" style="width:25%">Notes and links</th></tr>
@@ -292,13 +292,13 @@ The codebase MUST include contribution guidelines explaining what kinds of contr
 
 <tr>
 <td>
-
+Ok
 </td>
 <td>
 The codebase MUST document the governance of the codebase, contributions and its community, for example in a `GOVERNANCE` file.
 </td>
 <td>
-There is a <a href="https://github.com/govdirectory/website#maintainers">maintainers</a> section, but it could be more explicit what it means.
+In the <a href="https://github.com/govdirectory/website#maintainers">maintainers</a> section.
 </td>
 </tr>
 


### PR DESCRIPTION
More explicit about current state and future intentions.
Also changed Twitter to Mastodon as an alternative contact method.