### PR TITLE
🖼 Sticky footer

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -4,6 +4,9 @@ body {
     font-family: "Ubuntu", sans-serif;
     color: #333;
     font-size: .96em;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
 }
 
 ul {
@@ -233,7 +236,7 @@ footer {
     color: #fff;
     padding: 1em;
     height: 100%;
-    margin-top: 2em;
+    margin-top: auto;
 }
 
 .footer-table {
@@ -652,6 +655,7 @@ header.topic {
     .container {
         width: 1000px;
         margin: auto;
+        margin-top: 0%;
     }
 }
 


### PR DESCRIPTION
fixes #358 

To counteract the "floating" container (mentioned in #358), I used margin-top: 0%;
`@media screen and (min-width: 1000px) {
    .container {
        width: 1000px;
        margin: auto;
        margin-top: 0%;
    }`

But I'm not sold on the implementation. If anyone knows a better way, feel free to make a corrective commit ;-)