### PR TITLE
🇳🇿 Update new-zealand.rq

### DIFF
--- a/queries/generators/new-zealand.rq
+++ b/queries/generators/new-zealand.rq
@@ -1,4 +1,4 @@
-# expected_result_count: 144
+# expected_result_count: 124
 SELECT DISTINCT
   ?qid
   ?orgLabel
@@ -12,8 +12,7 @@ WHERE {
 
     # agencies with country set to New Zealand
     VALUES ?type {
-      wd:Q116973815 # public service departments (31)
-      wd:Q5283326 # district health board of New Zealand (20)
+      wd:Q116973815 # public service departments (32)
       wd:Q8041036 # wānanga (3)
       wd:Q1148315 # state-owned enterprise of New Zealand (12)
       wd:Q65600637 # regional council of New Zealand (11)


### PR DESCRIPTION
The district health board of New Zealand (Q5283326) was abolished on July 1, 2022 and replaced by Health New Zealand (Q109801969). The new agency is supposed to be an Crown agency ([reference](https://www.publicservice.govt.nz/system/central-government-organisations#Crown-entities)), but that section has not yet been finalized on the wiki project page.