### PR TITLE
🧼🧽 Clean up CSS

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -47,7 +47,7 @@ h2 {
 
 a, a:hover {
     text-decoration: underline;
-    color: #FFF;
+    color: #fff;
 }
 
 summary {
@@ -78,17 +78,17 @@ summary {
 }
 
 .text-orange {
-    color: #E66A49;
+    color: #e66a49;
 }
 
 .bg-grey {
-    background-color: #F8F4ED;
+    background-color: #f8f4ed;
 }
 
 .sticky-grey {
     position: sticky;
     top: 60px;
-    padding-bottom: 0px;
+    padding-bottom: 0;
 }
 
 .sticky-grey .move-away {
@@ -97,7 +97,7 @@ summary {
 }
 
 .bg-orange {
-    background: #E66A49;
+    background: #e66a49;
     padding: 20px 0;
 }
 
@@ -161,12 +161,12 @@ section {
     line-height: 1.55;
     font-size: clamp(1.5rem, 4vw, 3rem);
     margin: 0;
-    color: #FFF;
+    color: #fff;
 }
 
 @keyframes gradientBG {
   0% {
-    background-position: 0% 0%
+    background-position: 0 0
   }
 
   50% {
@@ -174,7 +174,7 @@ section {
   }
 
   100% {
-    background-position: 0% 0%
+    background-position: 0 0
   }
 }
 
@@ -203,10 +203,10 @@ nav li {
 nav a {
     line-height: 70px;
     text-align: center;
-    color: #FFF;
+    color: #fff;
     text-decoration: none;
     font-size: 1.1rem;
-    padding: 0px 20px;
+    padding: 0 20px;
     display: inline-block;
 }
 
@@ -215,14 +215,14 @@ nav img {
 }
 
 nav a:hover {
-    background-color: #E66A49;
-    color: #FFF;
+    background-color: #e66a49;
+    color: #fff;
 }
 
 /* LARGE CALL-OUT-BOX */
 
 .call-out {
-    background: #E66A49;
+    background: #e66a49;
     font-size: 1.5rem;
     padding: 1em;
     color: #fff;
@@ -232,7 +232,7 @@ nav a:hover {
 /* FOOTER */
 
 footer {
-    background-color: #062B58;
+    background-color: #062b58;
     color: #fff;
     padding: 1em;
     height: 100%;
@@ -261,7 +261,7 @@ footer li {
 }
 
 .white-bg {
-    background-color:#FFF;
+    background-color:#fff;
 }
 
 /* TABLE */
@@ -275,7 +275,7 @@ table {
 table thead {
 		position: sticky;
 		top: 164px;
-		background: white;
+		background: #fff;
 }
 
 table a {
@@ -296,7 +296,7 @@ table th {
 }
 
 table tr:nth-child(even) {
-    background-color: #F8F4ED;
+    background-color: #f8f4ed;
 }
 
 table ul li {
@@ -307,9 +307,9 @@ table ul li {
 table th:not(.js-sort-none)::after {
     content: "◆";
     padding-left: 3px;
-    font-size: 0.7em;
+    font-size: .7em;
     font-stretch: ultra-condensed;
-    line-height: 0.7em;
+    line-height: .7em;
 }
 
 table th:not(.js-sort-none):hover {
@@ -319,7 +319,7 @@ table th:not(.js-sort-none):hover {
 /* BUTTONS */
 
 .btn {
-    background: #062B58;
+    background: #062b58;
     color: #fff;
     text-decoration: none;
     text-align: center;
@@ -343,7 +343,7 @@ table th:not(.js-sort-none):hover {
 
 .btn.right {
     float: right;
-    margin: 0em;
+    margin: 0;
 }
 
 
@@ -376,7 +376,7 @@ table th:not(.js-sort-none):hover {
 .box-list li {
     height: 100px;
     line-height: 100px;
-    background: #E66A49;
+    background: #e66a49;
     border-radius: 3px;
 }
 
@@ -397,7 +397,7 @@ table th:not(.js-sort-none):hover {
 }
 
 .topic-list div {
-    background: #E66A49;
+    background: #e66a49;
     border-radius: 100%;
     height: 100px;
     text-align: center;
@@ -418,21 +418,21 @@ table th:not(.js-sort-none):hover {
 /* HEADER */
 
 header.item {
-    background: #E66A49;
+    background: #e66a49;
     margin-top: 2em;
     padding: 2em;
     color: #fff;
-    border-radius: 5px 5px 0px 0px;
+    border-radius: 5px 5px 0 0;
 }
 
 header.topic {
-    background: #062B5899;
+    background: #062b5899;
     margin-top: 2em;
     margin-left: 20%;
     margin-right: 20%;
     padding: 2em;
     color: #fff;
-    border-radius: 5px 5px 0px 0px;
+    border-radius: 5px 5px 0 0;
 }
 
 .header-lower {
@@ -458,7 +458,7 @@ header.topic {
 }
 
 .btn-list .wikidata-btn {
-    background-color: #FFF;
+    background-color: #fff;
     float: right;
     width: 18px;
     height: 18px;
@@ -483,7 +483,7 @@ header.topic {
 
 .timestamp {
     text-align: right;
-    margin-top: 0.5;
+    margin-top: .5em;
     margin-bottom: 0;
   }
 
@@ -552,14 +552,14 @@ header.topic {
 .spinner > div {
     width: 18px;
     height: 18px;
-    background-color: #E66A49;
+    background-color: #e56c4a;
     border-radius: 100%;
     display: inline-block;
     animation: dots 1.4s infinite ease-in-out both;
 }
 
-.spinner .dot1 { animation-delay: -0.32s; }
-.spinner .dot2 { animation-delay: -0.16s; }
+.spinner .dot1 { animation-delay: -.32s; }
+.spinner .dot2 { animation-delay: -.16s; }
 
 @keyframes dots {
   0%, 80%, 100% { transform: scale(0); }
@@ -655,7 +655,7 @@ header.topic {
     .container {
         width: 1000px;
         margin: auto;
-        margin-top: 0%;
+        margin-top: 0;
     }
 }
 

--- a/static/main.css
+++ b/static/main.css
@@ -261,7 +261,7 @@ footer li {
 }
 
 .white-bg {
-    background-color:#fff;
+    background-color: #fff;
 }
 
 /* TABLE */

--- a/static/main.css
+++ b/static/main.css
@@ -552,7 +552,7 @@ header.topic {
 .spinner > div {
     width: 18px;
     height: 18px;
-    background-color: #e56c4a;
+    background-color: #e66a49;
     border-radius: 100%;
     display: inline-block;
     animation: dots 1.4s infinite ease-in-out both;

--- a/templates/country-page.html
+++ b/templates/country-page.html
@@ -11,8 +11,8 @@
 <div class="container">
     <header class="item">
             <div class="btn-list">
-                <a class="btn rounded wikidata-btn" href="{{ .uri }}" title="Edit on Wikidata"><img loading="lazy" src="/wikidata.svg" aria-hidden="true"></a>
-                <a class="btn rounded wikidata-btn" href="https://www.wikidata.org/w/index.php?action=edit&title=Wikidata:WikiProject_Govdirectory/Error_reports&section=new&preloadtitle=Error+regarding+{{`{{`}}Q|{{ $countryID }}{{`}}`}}&preload=Wikidata%3AWikiProject_Govdirectory%2FError_reports%2FError_report_template" title="Report a problem"><img loading="lazy" src="/flag.svg" aria-hidden="true"></a>
+                <a class="btn rounded wikidata-btn" href="{{ .uri }}" title="Edit on Wikidata"><img loading="lazy" src="/wikidata.svg" aria-hidden="true" width="18" height="10" ></a>
+                <a class="btn rounded wikidata-btn" href="https://www.wikidata.org/w/index.php?action=edit&title=Wikidata:WikiProject_Govdirectory/Error_reports&section=new&preloadtitle=Error+regarding+{{`{{`}}Q|{{ $countryID }}{{`}}`}}&preload=Wikidata%3AWikiProject_Govdirectory%2FError_reports%2FError_report_template" title="Report a problem"><img loading="lazy" src="/flag.svg" aria-hidden="true" width="18" height="10"></a>
             </div>
         <h1 lang="{{ .name.Lang }}">{{ .name }}</h1>
         <p lang="{{ .nativeLabel.Lang }}">{{ .nativeLabel }}</p>

--- a/templates/org.html
+++ b/templates/org.html
@@ -58,8 +58,8 @@
         <div class="btn-list">
             <a class="btn rounded" href="/{{ $currentCountrySafeName }}/">{{ $currentCountryName }}</a>
             {{- if .cofog -}}<a class="btn rounded" href="/{{ $cofogSafeName }}/">{{ $cofogLabel }}</a>{{- end -}}
-            <a class="btn rounded wikidata-btn" href="https://www.wikidata.org/wiki/{{ .qid }}" title="Edit on Wikidata"><img loading="lazy" src="/wikidata.svg" aria-hidden="true"></a>
-            <a class="btn rounded wikidata-btn" href="https://www.wikidata.org/w/index.php?action=edit&title=Wikidata:WikiProject_Govdirectory/Error_reports&section=new&preloadtitle=Error+regarding+{{`{{`}}Q|{{ .qid }}{{`}}`}}&preload=Wikidata%3AWikiProject_Govdirectory%2FError_reports%2FError_report_template" title="Report a problem"><img loading="lazy" src="/flag.svg" aria-hidden="true"></a>
+            <a class="btn rounded wikidata-btn" href="https://www.wikidata.org/wiki/{{ .qid }}" title="Edit on Wikidata"><img loading="lazy" src="/wikidata.svg" aria-hidden="true" width="18" height="10"></a>
+            <a class="btn rounded wikidata-btn" href="https://www.wikidata.org/w/index.php?action=edit&title=Wikidata:WikiProject_Govdirectory/Error_reports&section=new&preloadtitle=Error+regarding+{{`{{`}}Q|{{ .qid }}{{`}}`}}&preload=Wikidata%3AWikiProject_Govdirectory%2FError_reports%2FError_report_template" title="Report a problem"><img loading="lazy" src="/flag.svg" aria-hidden="true" width="18" height="18"></a>
         </div>
         <h1 lang="{{ .orgLabel.Lang }}">{{ .orgLabel }}</h1>
         {{- if .orgDescription -}}


### PR DESCRIPTION
- unnecessary code removed (details)
- standardize colors (all in lowercase hex)
- set a fixed width and height of the round buttons. (no CSS)
- timestamp section has been fixed<br>
before: 
```
.timestamp {
    text-align: right;
    margin-top: 0.5;
    margin-bottom: 0;
```

after: 
 ```
.timestamp {
    text-align: right;
    margin-top: .5em;
    margin-bottom: 0;
  }
```
The unit was missing from margin-top.