### PR TITLE
set the client `theme_color` to GDs primary color

### DIFF
--- a/static/site.webmanifest
+++ b/static/site.webmanifest
@@ -4,7 +4,7 @@
     "start_url": "https://www.govdirectory.org/",
     "display" :"standalone",
     "background_color": "#ffffff",
-    "theme_color": "#094082",
+    "theme_color": "#00264d",
     "icons": [
         {
             "src": "/android-chrome-192x192.png",


### PR DESCRIPTION
The previous color is for buttons in focus. Could there have been a reason for this? Maybe it doesn't do well in some browsers?