### PR TITLE
Center grid class half

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -364,6 +364,7 @@ table th:not(.js-sort-none):hover {
 .half {
     display: grid;
     grid-template-columns: 1fr;
+    align-content: center;
 }
 
 .box-list {


### PR DESCRIPTION
Looks better (In my opinion)

The half class is used on the landing page, about page and tools page.
