### PR TITLE
Fix broken DPG link in footer

### DIFF
--- a/templates/layouts/layout.html
+++ b/templates/layouts/layout.html
@@ -101,7 +101,7 @@
         <div class="container footer-end">
             <a title="Go to Govdirectory's main page" href="/"><img loading="lazy" aria-hidden="true" src="/logo-white.svg" alt="" height="60" width="50"></a>
             <div>
-                <a title="Digital Public Goods" href="https://digitalpublicgoods.net/registry/govdirectory.html"><img loading="lazy" aria-hidden="true" height="33" width="69" src="/dpgbadge.svg"></a>
+                <a title="Digital Public Goods" href="https://app.digitalpublicgoods.net/a/11821"><img loading="lazy" aria-hidden="true" height="33" width="69" src="/dpgbadge.svg"></a>
                 <a title="Powered by Wikidata" href="https://www.wikidata.org"><img loading="lazy" aria-hidden="true" height="33" width="120" class="white-bg" src="/wikidatafooter.svg"></a>
             </div>
         </div>


### PR DESCRIPTION
It looks like they broke all the registry links when changing to an automated system.