### PR TITLE
🇲🇹 remove local councils of Malta

### DIFF
--- a/queries/countries.rq
+++ b/queries/countries.rq
@@ -40,7 +40,7 @@ WHERE {
     (wd:Q419 'Peru' 'peru' 'Current content includes ministries, regions and provinces.' '')
     (wd:Q40 'Austria' 'austria' 'Current content includes ministries, federated states, districts and municipalities.' '')
     (wd:Q189 'Iceland' 'iceland' 'Current content includes ministries, courts and municipalities.' '')
-    (wd:Q233 'Malta' 'malta' 'Current content includes ministries, regions and local councils.' '')
+    (wd:Q233 'Malta' 'malta' 'Current content includes ministries and regions.' '')
     (wd:Q1028 'Morocco' 'morocco' 'Current content includes ministries, embassies, regions, provinces and prefectures.' '')
     (wd:Q39 'Switzerland' 'switzerland' 'Current content includes federal ministries, cantons and municipalities.' '')
     (wd:Q1009 'Cameroon' 'cameroon' 'Current content includes ministries, regions, senate, lower house and supreme court.' '')

--- a/queries/generators/malta.rq
+++ b/queries/generators/malta.rq
@@ -1,4 +1,4 @@
-# expected_result_count: 92
+# expected_result_count: 24
 SELECT DISTINCT
   ?qid
   ?orgLabel
@@ -12,7 +12,6 @@ WHERE {
   VALUES ?type {
     wd:Q119774544 # Ministry of Malta (18)
     wd:Q7309296 # region of Malta (6)
-    wd:Q719592 # local council of Malta (68)
   }
   ?org wdt:P31 ?type .
 


### PR DESCRIPTION
# Description

This removes local councils of Malta, they are no longer marked as local councils of Malta but instead generic towns, typical example of an area where there needs to be a split between the location and administrative org so there is no easy fix in sight. 

## PR Details

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactor

## Checklist

Please **ensure** the following before submitting the PR:

- [x] I have **tested** the changes locally, and they work as expected.
- [x] The code follows the project's coding standards and conventions.
- [x] Any **query changes** have been verified and are working correctly.
- [x] I have **updated relevant documentation** (if needed).
- [ ] I have added unit **tests** or performed manual testing where necessary.
