### PR TITLE
Fix expected number of Canadian departments

### DIFF
--- a/queries/generators/canada.rq
+++ b/queries/generators/canada.rq
@@ -1,4 +1,4 @@
-# expected_result_count: 34
+# expected_result_count: 33
 SELECT DISTINCT
   ?qid
   ?orgLabel
@@ -10,7 +10,7 @@ WHERE {
    BIND(wd:Q16 AS ?country)
 
   VALUES ?type {
-    wd:Q111190932 # Ministerial departments (21)
+    wd:Q111190932 # Ministerial departments (20)
     wd:Q11828004 # Provinces (10)
     wd:Q9357527 # Territories (3)
   }


### PR DESCRIPTION
# Description

Should only be 20, as per our [source](https://en.wikipedia.org/wiki/Structure_of_the_Canadian_federal_government#Ministerial_departments).

## PR Details

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactor

## Checklist

Please **ensure** the following before submitting the PR:

- [x] I have **tested** the changes locally, and they work as expected.
- [x] The code follows the project's coding standards and conventions.
- [x] Any **query changes** have been verified and are working correctly.
- [ ] ~I have **updated relevant documentation** (if needed).~
- [ ] ~I have added unit **tests** or performed manual testing where necessary.~