### PR TITLE
Exclude generic mayors

### DIFF
--- a/queries/organization-optional.rq
+++ b/queries/organization-optional.rq
@@ -35,6 +35,7 @@ WHERE {
     ?person wdt:P31 wd:Q5 .
     MINUS { ?positionStatement pq:P582 ?endtime }
     MINUS { ?person wdt:P570 [] }
+    FILTER ( ?office != wd:Q30185 )
   }
 
   OPTIONAL {


### PR DESCRIPTION
# Description

Exclude generic mayors from office positions. Really, a hack due to this often being a cause of bad data, and if we see that the data is improved (a lot) we should remove this again.

## Issue Reference

Fixes #443.

## PR Details

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactor

## Checklist

Please **ensure** the following before submitting the PR:

- [x] I have **tested** the changes locally, and they work as expected.
- [x] The code follows the project's coding standards and conventions.
- [x] Any **query changes** have been verified and are working correctly.
- [ ] ~I have **updated relevant documentation** (if needed).~
- [ ] ~I have added unit **tests** or performed manual testing where necessary.~

