### PR TITLE
Fix Danish query to account for future orgs

### DIFF
--- a/queries/generators/denmark.rq
+++ b/queries/generators/denmark.rq
@@ -20,6 +20,7 @@ WHERE {
   MINUS { ?org wdt:P576 [] }
   MINUS { ?org wdt:P1366 [] }
   MINUS { ?org wdt:P3999 [] }
+  MINUS { ?org wdt:P571 ?start . FILTER (?start > NOW() ) }
 
   OPTIONAL {
     ?org wdt:P9798/wdt:P279* ?cofog .


### PR DESCRIPTION
# Description

One upcoming region was showing up in the query. 
This prevents all organizations with future start dates to show up.

## PR Details

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactor

## Checklist

Please **ensure** the following before submitting the PR:

- [x] I have **tested** the changes locally, and they work as expected.
- [x] The code follows the project's coding standards and conventions.
- [x] Any **query changes** have been verified and are working correctly.
- [ ] ~I have **updated relevant documentation** (if needed).~
- [ ] ~I have added unit **tests** or performed manual testing where necessary.~