### PR TITLE
Update count of Belgian municipalities

### DIFF
--- a/queries/generators/belgium.rq
+++ b/queries/generators/belgium.rq
@@ -50,4 +50,4 @@ UNION
 
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en,nl,fr,de" }
 }
-ORDER BY ?typeLabel ?type
+ORDER BY ?typeLabel ?orgLabel

--- a/queries/generators/belgium.rq
+++ b/queries/generators/belgium.rq
@@ -37,15 +37,9 @@ UNION
     wd:Q121856465 # delegations (8)
     wd:Q112307194 # consulate generals (15)
     wd:Q3917681 # embassies (83)
+    wd:Q5244910 #  de facto embassy (1)
 }
 ?org wdt:P31 ?type; wdt:P137 ?country .
-}
-UNION
-{
-  VALUES ?type {
-    wd:Q5244910 #  de facto embassy (1)
-  }
-  ?org wdt:P31 ?type; wdt:P17 wd:Q865; wdt:P137 ?country .
 }
   MINUS { ?org wdt:P576 [] }
   MINUS { ?org wdt:P1366 [] }
@@ -56,4 +50,4 @@ UNION
 
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en,nl,fr,de" }
 }
-ORDER BY ?type ?orgLabel
+ORDER BY ?typeLabel ?type

--- a/queries/generators/belgium.rq
+++ b/queries/generators/belgium.rq
@@ -1,4 +1,4 @@
-# expected_result_count: 991
+# expected_result_count: 990
 SELECT DISTINCT
 ?qid
 ?orgLabel
@@ -22,7 +22,7 @@ WHERE {
     wd:Q83116 # extant provinces (10)
     wd:Q2621126 # police zones (182)
     wd:Q3575878 # emergency zones (35)
-    wd:Q493522 # municipalities (581)
+    wd:Q493522 # municipalities (580)
     wd:Q190752 # supreme court (2)
     wd:Q32766 # constitutional court (1)
     wd:Q2570643 # senate (1)


### PR DESCRIPTION
# Description
The municipalities of [Bertogne ](https://www.wikidata.org/wiki/Q713118)and [Bastogne ](https://www.wikidata.org/wiki/Q34021)merged on December 2, 2024.
(There are many mergers taking place in January.)

## PR Details

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Code refactor

## Checklist

Please **ensure** the following before submitting the PR:

- [x] I have **tested** the changes locally, and they work as expected.
- [x] The code follows the project's coding standards and conventions.
- [x] Any **query changes** have been verified and are working correctly.

## Screenshots (applicable to user interface changes)

<!-- Attach screenshots if relevant. -->

