### PR TITLE
Add text wrapping

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -598,6 +598,12 @@ header.topic {
     table thead {
         top: 232px;
     }
+    table {
+        table-layout: fixed;
+    }
+    table td, table th {
+        text-wrap: balance;
+    }
 }
 
 @media screen and (min-width: 600px) {


### PR DESCRIPTION
# Description

I had first tested it with: 
 ` }
    table {
        table-layout:fixed;
    }
    table td, table th {
        word-break:break-word;
        overflow-wrap:break-word;
    }`
But ended up with text-wrap: balance;
Can I use [89,31%](https://caniuse.com/css-text-wrap-balance)
[MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap)

## Issue Reference

<!-- Optional link to the related issue in the repository. -->
Fixes #315 

## Checklist

Please **ensure** the following before submitting the PR:

- [x] I have **tested** the changes locally, and they work as expected.
- [x] The code follows the project's coding standards and conventions.

