### PR TITLE
Remove twitter specific meta tags

### DIFF
--- a/templates/layouts/layout.html
+++ b/templates/layouts/layout.html
@@ -48,13 +48,6 @@
     <meta property="og:title" content="Govdirectory" />
     <meta property="og:description" content="Govdirectory is a crowdsourced and fact checked directory of official governmental online accounts and services." />
 
-    <meta name="twitter:site" content="@govdirectory">
-    <meta name="twitter:creator" content="@govdirectory">
-    <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:url" content="https://www.govdirectory.org/" />
-    <meta property="twitter:title" content="Govdirectory" />
-    <meta property="twitter:description" content="Govdirectory is a crowdsourced and fact checked directory of official governmental online accounts and services." />
-    <meta property="twitter:image" content="/og-banner.jpg" />
     <meta name="generator" content="Snowman v{{ version }}">
     <link rel="license" href="https://creativecommons.org/publicdomain/zero/1.0/">
 


### PR DESCRIPTION
Either these are specific to Twitter or they are covered by our open graph tags.


