### PR TITLE
Add fallback for head of institution (fixes #98)

### DIFF
--- a/queries/organization-optional.rq
+++ b/queries/organization-optional.rq
@@ -28,14 +28,25 @@ WHERE {
 
   OPTIONAL { ?org wdt:P749 ?parentOrg }
 
-  OPTIONAL {
-    ?org wdt:P2388|wdt:P1313 ?office .
-    ?positionStatement ps:P39 ?office .
-    ?person p:P39 ?positionStatement .
-    ?person wdt:P31 wd:Q5 .
-    MINUS { ?positionStatement pq:P582 ?endtime }
-    MINUS { ?person wdt:P570 [] }
-    FILTER ( ?office != wd:Q30185 )
+    OPTIONAL {
+    {
+      ?org wdt:P2388|wdt:P1313 ?office .
+      ?positionStatement ps:P39 ?office .
+      ?person p:P39 ?positionStatement .
+      ?person wdt:P31 wd:Q5 .
+      MINUS { ?positionStatement pq:P582 ?endtime }
+      MINUS { ?person wdt:P570 [] }
+      FILTER ( ?office != wd:Q30185 )
+    }
+    UNION
+    {
+      { ?org wdt:P488 ?person } UNION
+      { ?org wdt:P169 ?person } UNION
+      { ?org wdt:P1037 ?person } UNION
+      { ?org wdt:P3975 ?person }
+      ?person wdt:P31 wd:Q5 .
+      MINUS { ?person wdt:P570 [] }
+    }
   }
 
   OPTIONAL {


### PR DESCRIPTION
## Changes
Implements fallback properties for institution heads as discussed in #98:
- P488 (chair)
- P169 (CEO)
- P1037 (director/manager)
- P3975 (secretary-general)

## Testing
Verified with:
- 🏛️ Berlin (Q64): Kai Wegner (position statement)
- 🏢 Microsoft (Q2283): Satya Nadella (CEO fallback)
- 🌐 United Nations (Q8073): António Guterres (P3975)

