### PR TITLE
Add NLnet Foundation funding into about page

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -74,6 +74,13 @@
       <p class="content">This project was initially supported through Wikimedia Deutschland's <a href="https://www.wikimedia.de/unlock/" class="dark-link">Unlock Accelerator</a>. <a class="dark-link" href="https://wikimedia.se/">Wikimedia Sverige</a> is graciously providing us with Matomo analytics. The data we collect is <a class="dark-link" href="https://matomo.wikimedia.se/index.php?module=CoreHome&action=index&idSite=7&period=day&date=yesterday#?idSite=7&period=day&date=yesterday&segment=&category=Dashboard_Dashboard&subcategory=1">publicly accessible</a>.</p>
     </div>
   </section>
+  <section>
+    <div class="container center-text">
+      <h2 class="h2-lg">NLnet Foundation</h2>
+      <p class="content">This project has received funding from the <a href="https://nlnet.nl/" class="dark-link" target="_blank">NLnet Foundation</a>, a non-profit organization that supports projects improving the open internet. The funding comes through their <strong>NGI Zero Core program</strong>, which focuses on privacy, trust, and decentralization in internet technologies.
+    </p>
+    </div>
+  </section>
 </main>
 {{ end }}
 


### PR DESCRIPTION
# Description

Added and styled the **About Page** to include project background and funding acknowledgment.  
The page now highlights the role of the **NLnet Foundation** and the **NGI Zero Core program**, explaining their contribution to supporting open, privacy-focused, and decentralized internet technologies.

---

## Issue Reference

Fixes #553 

---

## Checklist

- [x] ✅ I have tested the About Page locally and confirmed it renders correctly.  
- [x] 📝 The code follows the project's coding standards and conventions.  
- [x] 📚 I have updated relevant documentation if needed.  
- [ ] 🧪 I have added unit tests or performed manual testing where necessary.  

---

## Screenshots (applicable to user interface changes)

**NLnet Foundation Section**  

![About Page - NLnet Funding Section](https://github.com/user-attachments/assets/fde13125-caac-46e2-95ab-ec174d47df83)


