### PR TITLE
Fix count for Sweden

### DIFF
--- a/queries/generators/sweden.rq
+++ b/queries/generators/sweden.rq
@@ -1,4 +1,4 @@
-# expected_result_count: 775
+# expected_result_count: 774
 SELECT DISTINCT
   ?qid
   ?orgLabel
@@ -13,7 +13,7 @@ WHERE {
   {
     # agencies with country set to Sweden
     VALUES ?type {
-      wd:Q68295960 # Swedish government agency (254) ✔
+      wd:Q68295960 # Swedish government agency (253) ✔
       wd:Q107407151 # Swedish government agency under the parliament (12) ✔
       wd:Q127448 # municipality of Sweden (290) ✔
       wd:Q1754161 # regional council in Sweden (20) ✔


### PR DESCRIPTION
# Description

Bankinspektionen (Q10426065) was wrongly counted before, adjusted to 253 government agencies.

## Checklist

Please **ensure** the following before submitting the PR:

- [x] I have **tested** the changes locally, and they work as expected.
