### PR TITLE
Remove subnational entities from countries on landing page

### DIFF
--- a/templates/landing.html
+++ b/templates/landing.html
@@ -69,6 +69,9 @@
       <div class="btn-list">
         {{- $countries := query "countries.rq" -}}
         {{- range $countries -}}
+        {{- if contains .safeName "/" -}}
+            {{- continue -}}
+        {{- end -}}
           <a href="{{ .safeName }}/" class="btn rounded">{{ .name }}</a>
         {{- end -}}
       </div>


### PR DESCRIPTION
# Description

On the landing page, subnational entities like Scotland and North Carolina was shown under Explore countries.
That doesn't match. This filters the same way as the listing on the country page.
 
## Checklist

Please **ensure** the following before submitting the PR:

- [x] I have **tested** the changes locally, and they work as expected.
- [x] The code follows the project's coding standards and conventions.