### PR TITLE
Add fallback for missing head of institution name

### DIFF
--- a/queries/organization-optional.rq
+++ b/queries/organization-optional.rq
@@ -39,7 +39,6 @@ WHERE {
   }
 
   OPTIONAL {
-
     ?org wdt:P488|wdt:P169|wdt:P1037|wdt:P3975 ?person .
   }
 


### PR DESCRIPTION
Made a small update to improve how we pull the head of an institution:

-->Added a few fallback properties like chair (P488), CEO (P169), director (P1037), and Secretary-General (P3975)
-->Also added a COALESCE so if the name’s missing, it’ll show “Not Available” instead
This should help keep the results meaningful even when the main leader info isn’t there.
Appreciate you taking the time to review it!
