### PR TITLE
Correct spelling of 'Minimal' to 'Minimum'

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Besides pinging us in [issues](https://github.com/govdirectory/website/issues), 
 
 This project participated in the [Unlock accelerator program](https://www.wikimedia.de/unlock/) program ([original application](https://www.wikidata.org/wiki/User:Ainali/Social_media_for_public_organizations/Unlock)).
 
-During the accelerator, which ended in October 2021, we defined a Minimal Viable Product (MVP) to: "As an MVP we want to create a working website where people can search, filter, and add data about Swedish and British public institutions and their social media accounts."
+During the accelerator, which ended in October 2021, we defined a Minimum Viable Product (MVP) to: "As an MVP we want to create a working website where people can search, filter, and add data about Swedish and British public institutions and their social media accounts."
 
 Specifically, we want to acknowledge all the help our coach [Fabian Gampp](https://www.fabiangampp.de/) gave to us. Besides general good mentorship, we wouldn't have had such a bold direction of the design of the website without him.
 


### PR DESCRIPTION
# Description

Just a small fix — corrected the MVP definition to use the standard term "Minimum Viable Product".