### PR TITLE
Rename federal subjects to "Parts of (country)"

### DIFF
--- a/ADD_A_COUNTRY.md
+++ b/ADD_A_COUNTRY.md
@@ -140,7 +140,7 @@ SELECT
   ?name
   ?safeName
   ?description
-  ?federalSubjects
+  ?parts
   (SAMPLE(?website) AS ?website)
   (SAMPLE(?nativeLabel) AS ?nativeLabel)
   (GROUP_CONCAT(DISTINCT ?typeOfGovLabel; separator=",") AS ?typeOfGovList)
@@ -149,7 +149,7 @@ SELECT
   ?geoshape
   ?wikipedia
 WHERE {
-  VALUES (?uri ?name ?safeName ?description ?federalSubjects) {
+  VALUES (?uri ?name ?safeName ?description ?parts) {
     (wd:Q34 'Sweden' 'sweden' 'All Swedish government agencies are included.' '')
     (wd:Q223 'Greenland' 'greenland' 'Current content includes municipalities.' '')
   }
@@ -181,7 +181,7 @@ WHERE {
     ?typeOfGov rdfs:label ?typeOfGovLabel .
   }
 }
-GROUP BY ?uri ?name ?safeName ?description ?federalSubjects ?headOfGovLabel ?headOfStateLabel ?geoshape ?wikipedia
+GROUP BY ?uri ?name ?safeName ?description ?parts ?headOfGovLabel ?headOfStateLabel ?geoshape ?wikipedia
 ORDER BY ?name
 ```
 

--- a/jargon.txt
+++ b/jargon.txt
@@ -80,7 +80,6 @@ endif
 english
 eq
 facto
-federalSubjects
 Fediverse
 ffffff
 fi

--- a/queries/countries.rq
+++ b/queries/countries.rq
@@ -3,7 +3,7 @@ SELECT
   ?name
   ?safeName
   ?description
-  ?federalSubjects
+  ?parts
   (SAMPLE(?website) AS ?website)
   (SAMPLE(?nativeLabel) AS ?nativeLabel)
   (GROUP_CONCAT(DISTINCT ?typeOfGovLabel; separator=",") AS ?typeOfGovList)
@@ -12,7 +12,7 @@ SELECT
   ?geoshape
   ?wikipedia
 WHERE {
-  VALUES (?uri ?name ?safeName ?description ?federalSubjects) {
+  VALUES (?uri ?name ?safeName ?description ?parts) {
     (wd:Q34 'Sweden' 'sweden' 'All Swedish government agencies are included.' '')
     (wd:Q223 'Greenland' 'greenland' 'Current content includes municipalities.' '')
     (wd:Q35 'Denmark' 'denmark' 'Current content includes, ministries, regions and municipalities.' '')
@@ -90,5 +90,5 @@ WHERE {
     ?typeOfGov rdfs:label ?typeOfGovLabel .
   }
 }
-GROUP BY ?uri ?name ?safeName ?description ?federalSubjects ?headOfGovLabel ?headOfStateLabel ?geoshape ?wikipedia
+GROUP BY ?uri ?name ?safeName ?description ?parts ?headOfGovLabel ?headOfStateLabel ?geoshape ?wikipedia
 ORDER BY ?name

--- a/templates/country-page.html
+++ b/templates/country-page.html
@@ -46,13 +46,13 @@
     <p class="timestamp">Data last updated <time datetime="{{ now.Format "2006-01-02" }}">{{ now.Format "2006-01-02" }}</time>.</p>
     </header>
 
-    {{- if gt (len .federalSubjects.String) 0 -}}
+    {{- if gt (len .parts.String) 0 -}}
     <details>
-        <summary>Federal subjects</summary>
+        <summary>Parts of {{ .name }}</summary>
         <ul class="box-list">
-            {{- range split .federalSubjects "," -}}
-                {{- $federal_subject_details := split . "|" -}}
-                <li><a href="{{ index $federal_subject_details 1 }}">{{ index $federal_subject_details 0 }}</a></li>
+            {{- range split .parts "," -}}
+                {{- $part_details := split . "|" -}}
+                <li><a href="{{ index $part_details 1 }}">{{ index $part_details 0 }}</a></li>
             {{- end -}}
         </ul>
     </details>


### PR DESCRIPTION
# Description

Changing the term Federal subjects to Parts of (country).
I tried to cover both the UI, queries and documentation to reduce future confusion.

## Issue Reference

Fixes #569

## Checklist

Please **ensure** the following before submitting the PR:

- [x] I have **tested** the changes locally, and they work as expected.
- [x] The code follows the project's coding standards and conventions.
- [x] I have **updated relevant documentation** (if needed).