### PR TITLE
Exclude any reason for deprecated rank accounts

### DIFF
--- a/queries/account-data.rq
+++ b/queries/account-data.rq
@@ -16,7 +16,7 @@ WHERE {
   ?statement ?propValuePredicate ?value .
 
   MINUS { ?statement pq:P582 [] }
-  MINUS { ?statement pq:P2241 [] }
+  MINUS { ?statement wikibase:rank wikibase:DeprecatedRank }
 
   BIND(IRI(REPLACE(?formatter, '\\$1', ?value)) AS ?url)
 


### PR DESCRIPTION
# Description

I often see that the property “reason for downgraded rank” has been added, but no end date, which means that those accounts still appear on the website. Example: [Federal Ministry for Economic Affairs and Climate Action](https://www.govdirectory.org/germany/Q488589/)

