### PR TITLE
Add navigation from federal subject to country

### DIFF
--- a/templates/topic-page.html
+++ b/templates/topic-page.html
@@ -14,19 +14,19 @@
 
 <main>
 
-    {{ if .country }}
-    <div class="container">
-        <nav class="back-to-country">
-            <a href="{{> helpers/get-country-url .safeName }}">
-                ← Back to {{ .country.name }}
-            </a>
-        </nav>
-    </div>
-    {{ end }}
+   {{ if (strings.Contains .safeName "/") }}
+<div class="container">
+    <nav class="back-to-country">
+        <a href="{{> helpers/get-country-url .safeName }}">
+            ← Back to country
+        </a>
+    </nav>
+</div>
+{{ end }}
+
 
     <section class="bg-grey sticky-grey">
 
-    <section class="bg-grey sticky-grey">
         <div class="container">
 						<div class="move-away">
 								<div class="expand-mobile">


### PR DESCRIPTION
## Description

This PR adds a simple back-navigation link on federal subject pages, allowing users to navigate back to the parent country page easily.

The link is displayed only when a country context exists and uses the existing helper to generate the correct country URL.

## Issue Reference

Fixes #357

## Checklist

- [ ] I have tested the changes locally, and they work as expected.
- [x] The code follows the project's coding standards and conventions.
- [ ] I have updated relevant documentation (not required for this change).
- [ ] I have added unit tests or performed manual testing where necessary (not applicable for this template change).

## Screenshots

Not applicable (small template-only change).
