### PR TITLE
Update Belgium count

### DIFF
--- a/queries/countries.rq
+++ b/queries/countries.rq
@@ -28,7 +28,7 @@ WHERE {
     (wd:Q574 'East Timor' 'east-timor' 'Current content includes ministries, municipalities, special administrative region, administrative posts and sucos.' '')
     (wd:Q928 'Philippines' 'philippines' 'Current content includes departments, regions, provinces, cities and municipalities.' '')
     (wd:Q668 'India' 'india' 'Current content includes ministries, states and union territories.' '')
-    (wd:Q31 'Belgium' 'belgium' 'Current content includes federal scientific institutes, public institutions of social security, public interest organizations, federal public services, public planning services, agencies abroad, language areas, communities, regions, extant provinces, police zones, emergency zones and municipalities.' '')
+    (wd:Q31 'Belgium' 'belgium' 'Current content includes federal scientific institutes, public institutions of social security, public interest organizations, federal public services, public planning services, agencies abroad, communities, regions, extant provinces, police zones, emergency zones and municipalities.' '')
     (wd:Q16 'Canada' 'canada' 'Current content includes ministerial departments, provinces and territories.' '')
     (wd:Q252 'Indonesia' 'indonesia' 'Current content includes ministries, provinces, cities and regencies.' '')
     (wd:Q32 'Luxembourg' 'luxembourg' 'Current content includes ministries, ministries departments, cantons and communes.' '')

--- a/queries/generators/belgium.rq
+++ b/queries/generators/belgium.rq
@@ -1,4 +1,4 @@
-# expected_result_count: 973
+# expected_result_count: 968
 SELECT DISTINCT
 ?qid
 ?orgLabel
@@ -11,12 +11,11 @@ WHERE {
 {
   VALUES ?type {
     wd:Q2288140 # Federal Scientific Institutes (13)
-    wd:Q107637441 # Public Institution of Social Security (12)
+    wd:Q107637441 # Public Institution of Social Security (11)
     wd:Q3356161 # Public Interest Organizations (16)
     wd:Q1846372 # Federal Public Service (11)
     wd:Q1788820 # defence ministry (1)
     wd:Q21004446 # Public Planning Service (3)
-    wd:Q17373496 # language areas (4)
     wd:Q89934 # communities (3)
     wd:Q83057 # regions (3)
     wd:Q83116 # extant provinces (10)


### PR DESCRIPTION
# Description

I removed the language areas because they should not have been included in the first place.
updated the count of Q107637441 # Public Institution of Social Security  -> 11 (#608)

Q2288140 # Federal scientific institutes: currently mixed - I have several sources (2 official and 2 wikis nl, fr), but they all give a different total. 

I have removed a [paper launched agency](https://www.wikidata.org/wiki/Q107650041) and replaced by a [missing agency](https://www.wikidata.org/wiki/Q2226397). 

## Checklist

Please **ensure** the following before submitting the PR:

- [x] I have **tested** the changes locally, and they work as expected.
- [x] The code follows the project's coding standards and conventions.
