### PR TITLE
Fix wrong country shown for sub-national organizations

### DIFF
--- a/templates/org.html
+++ b/templates/org.html
@@ -56,11 +56,33 @@
 <div class="container">
     <header class="item">
         <div class="btn-list">
-            <a class="btn rounded" href="/{{ $currentCountrySafeName }}/">{{ $currentCountryName }}</a>
-            {{- if .cofog -}}<a class="btn rounded" href="/{{ $cofogSafeName }}/">{{ $cofogLabel }}</a>{{- end -}}
-            <a class="btn rounded wikidata-btn" href="https://www.wikidata.org/wiki/{{ .qid }}" title="Edit on Wikidata"><img loading="lazy" src="/wikidata.svg" aria-hidden="true" width="18" height="10"></a>
-            <a class="btn rounded wikidata-btn" href="https://www.wikidata.org/w/index.php?action=edit&title=Wikidata:WikiProject_Govdirectory/Error_reports&section=new&preloadtitle=Error+regarding+{{`{{`}}Q|{{ .qid }}{{`}}`}}&preload=Wikidata%3AWikiProject_Govdirectory%2FError_reports%2FError_report_template" title="Report a problem"><img loading="lazy" src="/flag.svg" aria-hidden="true" width="18" height="18"></a>
-        </div>
+    {{- if $parentOrgLabel -}}
+        <a class="btn rounded" href="/{{ $currentCountrySafeName }}/{{ $parentOrgQID }}">
+            {{ $parentOrgLabel }}
+        </a>
+    {{- else -}}
+        <a class="btn rounded" href="/{{ $currentCountrySafeName }}/">
+            {{ $currentCountryName }}
+        </a>
+    {{- end -}}
+
+    {{- if .cofog -}}
+        <a class="btn rounded" href="/{{ $cofogSafeName }}/">{{ $cofogLabel }}</a>
+    {{- end -}}
+
+    <a class="btn rounded wikidata-btn"
+       href="https://www.wikidata.org/wiki/{{ .qid }}"
+       title="Edit on Wikidata">
+        <img loading="lazy" src="/wikidata.svg" aria-hidden="true" width="18" height="10">
+    </a>
+
+    <a class="btn rounded wikidata-btn"
+       href="https://www.wikidata.org/w/index.php?action=edit&title=Wikidata:WikiProject_Govdirectory/Error_reports&section=new&preloadtitle=Error+regarding+{{`{{`}}Q|{{ .qid }}{{`}}`}}&preload=Wikidata%3AWikiProject_Govdirectory%2FError_reports%2FError_report_template"
+       title="Report a problem">
+        <img loading="lazy" src="/flag.svg" aria-hidden="true" width="18" height="18">
+    </a>
+</div>
+
         <h1 lang="{{ .orgLabel.Lang }}">{{ .orgLabel }}</h1>
         {{- if .orgDescription -}}
             <p lang="{{ .orgDescription.Lang }}">{{ .orgDescription }}</p>


### PR DESCRIPTION
Update the organization page to display the parent organization instead of the country for sub-national entities.

Falls back to showing the country when no parent organization exists. This change only affects display logic and does not modify data.

Fixes #576

# Description

<!-- Please include a summary of the changes and the related issue. Include any relevant context here. -->

## Issue Reference

<!-- Optional link to the related issue in the repository. -->
Fixes #(issue)

## Checklist

Please **ensure** the following before submitting the PR:

- [ ] I have **tested** the changes locally, and they work as expected.
- [ ] The code follows the project's coding standards and conventions.
- [ ] I have **updated relevant documentation** (if needed).
- [ ] I have added unit **tests** or performed manual testing where necessary.

## Screenshots (applicable to user interface changes)

<!-- Attach screenshots if relevant. -->

