### PR TITLE
Convert Recognition section to bullet list

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -17,54 +17,48 @@
   <section>
     <div class="container center-text">
       <h2 class="h2-lg">Vision</h2>
-      <p>Our vision is a world where people are empowered to engage with their government to ensure responsive,
-        inclusive, participatory and representative decision-making at all levels.</p>
+      <p>Our vision is a world where people are empowered to engage with their government to ensure responsive, inclusive, participatory and representative decision-making at all levels.</p>
     </div>
   </section>
   <section class="bg-grey">
     <div class="container center-text">
       <h2 class="h2-lg">Mission</h2>
-      <p>We will enable a community powered directory where the online presence of every public organization is easily
-        findable, queryable and trustworthy.</p>
+      <p>We will enable a community powered directory where the online presence of every public organization is easily findable, queryable and trustworthy.</p>
     </div>
   </section>
   <section>
     <div class="container">
       <div class="half">
         <div class="center-text">
-          <img loading="lazy" aria-hidden="true" src="/community.svg" width="261" height="161" />
+          <img loading="lazy" aria-hidden="true" src="/community.svg" width="261" height="161"/>
         </div>
         <div>
           <h2>Built by a community</h2>
-          <p>Support our efforts in creating transparency about governmental institutions and their activities online
-          </p>
-          <a class="btn" href="https://www.wikidata.org/wiki/Wikidata:WikiProject_Govdirectory">Learn more about the
-            community</a>
+          <p>Support our efforts in creating transparency about governmental institutions and their activities online</p>
+          <a class="btn" href="https://www.wikidata.org/wiki/Wikidata:WikiProject_Govdirectory">Learn more about the community</a>
         </div>
       </div>
     </div>
   </section>
-  <section class="bg-grey">
+    <section class="bg-grey">
     <div class="container">
       <div class="half">
         <div>
           <h2>Data quality through constant curation</h2>
-          <p>Based on Wikipedia's sister project Wikidata the data is constantly fact checked by a rigorous and
-            dedicated community. With the help of tools that help monitor changes in data and entering data correctly,
-            collectively the data can be kept up to date and accurate.</p>
+          <p>Based on Wikipedia's sister project Wikidata the data is constantly fact checked by a rigorous and dedicated community. With the help of tools that help monitor changes in data and entering data correctly, collectively the data can be kept up to date and accurate.</p>
         </div>
         <div class="center-text">
-          <img loading="lazy" aria-hidden="true" src="/curation.svg" width="271" height="258" />
+          <img loading="lazy" aria-hidden="true" src="/curation.svg" width="271" height="258"/>
+        </div>
         </div>
       </div>
-    </div>
     </div>
   </section>
   <section>
     <div class="container">
       <div class="half">
         <div class="center-text center-content">
-          <img loading="lazy" aria-hidden="true" src="/trophy.svg" width="140" height="182" />
+          <img loading="lazy" aria-hidden="true" src="/trophy.svg" width="140" height="182"/>
         </div>
         <div>
           <h2>Recognition</h2>
@@ -77,7 +71,7 @@
               </a>
               from the Free Software Foundation.
             </li>
-
+          
             <li>
               <strong>2024 –</strong>
               Selected as a champion in the
@@ -87,7 +81,7 @@
               </a>
               in the category "The role of governments and all stakeholders in the promotion of ICTs for development".
             </li>
-
+          
             <li>
               <strong>September 2023 –</strong>
               Finalist in the category Peace – Building peaceful and inclusive societies in the
@@ -95,7 +89,7 @@
                 SDG Game Changes Award
               </a>.
             </li>
-
+          
             <li>
               <strong>September 2022 –</strong>
               Recognized as a
@@ -104,31 +98,23 @@
               </a>
               by the Digital Public Goods Alliance.
             </li>
-
+          
             <li>
               <strong>2021 –</strong>
               Won a
-              <a href="https://upload.wikimedia.org/wikipedia/commons/8/8f/WikidataCon_Awards_2021.pdf#page=14"
-                class="dark-link">
+              <a href="https://upload.wikimedia.org/wikipedia/commons/8/8f/WikidataCon_Awards_2021.pdf#page=14" class="dark-link">
                 WikidataCon community award
               </a>.
             </li>
           </ul>
         </div>
-
       </div>
-    </div>
     </div>
   </section>
   <section class="bg-grey">
     <div class="container center-text">
       <h2 class="h2-lg">Acknowledgements</h2>
-      <p class="content">This project was initially supported through Wikimedia Deutschland's <a
-          href="https://www.wikimedia.de/unlock/" class="dark-link">Unlock Accelerator</a>. <a class="dark-link"
-          href="https://wikimedia.se/">Wikimedia Sverige</a> is graciously providing us with Matomo analytics. The data
-        we collect is <a class="dark-link"
-          href="https://matomo.wikimedia.se/index.php?module=CoreHome&action=index&idSite=7&period=day&date=yesterday#?idSite=7&period=day&date=yesterday&segment=&category=Dashboard_Dashboard&subcategory=1">publicly
-          accessible</a>.</p>
+      <p class="content">This project was initially supported through Wikimedia Deutschland's <a href="https://www.wikimedia.de/unlock/" class="dark-link">Unlock Accelerator</a>. <a class="dark-link" href="https://wikimedia.se/">Wikimedia Sverige</a> is graciously providing us with Matomo analytics. The data we collect is <a class="dark-link" href="https://matomo.wikimedia.se/index.php?module=CoreHome&action=index&idSite=7&period=day&date=yesterday#?idSite=7&period=day&date=yesterday&segment=&category=Dashboard_Dashboard&subcategory=1">publicly accessible</a>.</p>
     </div>
   </section>
 </main>


### PR DESCRIPTION
Description: 
This PR converts the Recognition section on the About page from a paragraph into a bullet list for improved readability.

The awards are ordered from newest to oldest to make future updates easier. All original wording and links are preserved.

closes #624
 
Checklist:
- [x] I have tested the changes locally, and they work as expected.
- [x] The code follows the project's coding standards and conventions. 
 
<img width="1896" height="826" alt="Screenshot 2026-02-19 193637" src="https://github.com/user-attachments/assets/d6cfb510-a64f-451b-9b70-921d15c0dfe0" />

 