### PR TITLE
feat: add intergovernmental organization template for Wikidata

### DIFF
--- a/templates/organization-page.html
+++ b/templates/organization-page.html
@@ -1,0 +1,43 @@
+---
+layout: default
+---
+
+<h1>{{ name }}</h1>
+
+<p><strong>Type:</strong> Intergovernmental Organization</p>
+
+{% if description %}
+<p>{{ description }}</p>
+{% endif %}
+
+{% if inception %}
+<p><strong>Founded:</strong> {{ inception }}</p>
+{% endif %}
+
+{% if headquarters %}
+<p><strong>Headquarters:</strong> {{ headquarters }}</p>
+{% endif %}
+
+{% if members %}
+<h2>Members</h2>
+<ul>
+  {% for member in members %}
+    <li>{{ member }}</li>
+  {% endfor %}
+</ul>
+{% endif %}
+
+{% if leadership %}
+<h2>Leadership</h2>
+<ul>
+  {% for leader in leadership %}
+    <li>{{ leader }}</li>
+  {% endfor %}
+</ul>
+{% endif %}
+
+{% if website %}
+<p><strong>Official Website:</strong> 
+  <a href="{{ website }}" target="_blank">{{ website }}</a>
+</p>
+{% endif %}


### PR DESCRIPTION
## Description

This PR introduces a new template for intergovernmental organizations.

## Changes

* Created `organization-page.html` based on the existing country template
* Removed country-specific fields such as administrative units
* Added support for member-based structure (e.g., EU, UN, NATO)
* Kept structure flexible for different organization types

## Issue Reference

Fixes #649

## Notes

This template is designed to minimize required modifications when creating pages for organizations like NATO, EU, or the UN.
