### PR TITLE
feat: add native labels for Agencies

### DIFF
--- a/queries/organization-optional.rq
+++ b/queries/organization-optional.rq
@@ -10,6 +10,7 @@ SELECT
   (SAMPLE(?regulatoryTextTitle ) AS ?regulatoryTextTitle)
   (SAMPLE(?personLabel) AS ?leadBy)
   (SAMPLE(?parentOrg) AS ?parent)
+  (SAMPLE(?nativeLabel) AS ?nativeLabel)
   ?wikipedia
 WHERE {
   BIND(wd:{{.}} AS ?org)
@@ -53,6 +54,16 @@ WHERE {
     ?wikipedia schema:about ?org ;
                schema:isPartOf <https://en.wikipedia.org/> .
   }
+  
+  OPTIONAL {
+    ?org wdt:P1705 ?nativeLabel .
+
+    ?org wdt:P17 ?country .
+    ?country wdt:P37 ?lang .
+    ?lang wdt:P424 ?langCode .
+
+    FILTER(LANG(?nativeLabel) = ?langCode)
+}
 
   SERVICE wikibase:label {
     # this might need to be updated when new countries are added

--- a/templates/org.html
+++ b/templates/org.html
@@ -62,6 +62,9 @@
             <a class="btn rounded wikidata-btn" href="https://www.wikidata.org/w/index.php?action=edit&title=Wikidata:WikiProject_Govdirectory/Error_reports&section=new&preloadtitle=Error+regarding+{{`{{`}}Q|{{ .qid }}{{`}}`}}&preload=Wikidata%3AWikiProject_Govdirectory%2FError_reports%2FError_report_template" title="Report a problem"><img loading="lazy" src="/flag.svg" aria-hidden="true" width="18" height="18"></a>
         </div>
         <h1 lang="{{ .orgLabel.Lang }}">{{ .orgLabel }}</h1>
+        {{- if $details.nativeLabel -}}
+            <p lang="{{ $details.nativeLabel.Lang }}">{{ $details.nativeLabel }}</p>
+        {{- end -}}
         {{- if .orgDescription -}}
             <p lang="{{ .orgDescription.Lang }}">{{ .orgDescription }}</p>
         {{- end -}}


### PR DESCRIPTION
# Description

Adds support for displaying an organization's native/official name below the primary organization label, following the same pattern used for country pages.

## Issue Reference

Fixes #654 

## Checklist

* [ ] I have tested the changes locally, and they work as expected.
* [x] The code follows the project's coding standards and conventions.
* [ ] I have updated relevant documentation (if needed).
* [ ] I have added unit tests or performed manual testing where necessary.

### Notes

I was able to set up the project locally, however full site builds were intermittently failing due to WDQS (Wikidata Query Service) returning HTTP 502 responses during page generation. Because of this I could not fully validate the rendered output locally.

The implementation follows the existing country native-label rendering pattern.

