### PR TITLE
Make statistics table sortable

### DIFF
--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -7,59 +7,62 @@
 {{ define "main" }}
 {{- $org_count := 0 -}}
 {{- range . -}}
-    {{- $country := .safeName.String -}}
-    {{- $orgs := query (join "" "generators/" $country ".rq") -}}
-    {{- $org_count = add (len $orgs) $org_count -}}
+{{- $country := .safeName.String -}}
+{{- $orgs := query (join "" "generators/" $country ".rq") -}}
+{{- $org_count = add (len $orgs) $org_count -}}
 {{- end -}}
 
 {{- $country_count := 0 -}}
 {{- range . -}}
-    {{- if contains .safeName "/" -}}
-        {{- continue -}}
-    {{- end -}}
-    {{- $country_count = add1 $country_count -}}
+{{- if contains .safeName "/" -}}
+{{- continue -}}
+{{- end -}}
+{{- $country_count = add1 $country_count -}}
 {{- end -}}
 
 {{- $social_count := 0 -}}
 {{- range . -}}
-    {{- $country := .safeName.String -}}
-    {{- $orgs := query (join "" "generators/" $country ".rq") -}}
-    {{- range $orgs -}}
-        {{ $social_count = add (len (query "account-data.rq" .qid.String)) $social_count }}
-    {{- end -}}
+{{- $country := .safeName.String -}}
+{{- $orgs := query (join "" "generators/" $country ".rq") -}}
+{{- range $orgs -}}
+{{ $social_count = add (len (query "account-data.rq" .qid.String)) $social_count }}
+{{- end -}}
 {{- end -}}
 
 {{- $other_contact_points := 0 -}}
 {{- range . -}}
-    {{- $country := .safeName.String -}}
-    {{- $orgs := query (join "" "generators/" $country ".rq") -}}
-    {{- range $orgs -}}
-        {{- $org_details := index (query "organization-optional.rq" .qid.String) 0 -}}
+{{- $country := .safeName.String -}}
+{{- $orgs := query (join "" "generators/" $country ".rq") -}}
+{{- range $orgs -}}
+{{- $org_details := index (query "organization-optional.rq" .qid.String) 0 -}}
 
-        {{- if $org_details.email -}}
-            {{- $other_contact_points = add1 $other_contact_points -}}
-        {{- end -}}
+{{- if $org_details.email -}}
+{{- $other_contact_points = add1 $other_contact_points -}}
+{{- end -}}
 
-        {{- if $org_details.website -}}
-            {{- $other_contact_points = add1 $other_contact_points -}}
-        {{- end -}}
+{{- if $org_details.website -}}
+{{- $other_contact_points = add1 $other_contact_points -}}
+{{- end -}}
 
-        {{- if $org_details.phone -}}
-            {{- $other_contact_points = add1 $other_contact_points -}}
-        {{- end -}}
+{{- if $org_details.phone -}}
+{{- $other_contact_points = add1 $other_contact_points -}}
+{{- end -}}
 
-        {{- if $org_details.contactPage -}}
-            {{- $other_contact_points = add1 $other_contact_points -}}
-        {{- end -}}
+{{- if $org_details.contactPage -}}
+{{- $other_contact_points = add1 $other_contact_points -}}
+{{- end -}}
 
-        {{- if $org_details.citizensInitiatives -}}
-            {{- $other_contact_points = add1 $other_contact_points -}}
-        {{- end -}}
-    {{- end -}}
+{{- if $org_details.citizensInitiatives -}}
+{{- $other_contact_points = add1 $other_contact_points -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 <main class="container">
     <h1>Statistics</h1>
-    <p>Last updated <time datetime="{{ now.Format "2006-01-02" }}">{{ now.Format "2006-01-02" }}</time>. Live website usage statistics are publicly accessible through <a class="dark-link" href="https://matomo.wikimedia.se/index.php?module=CoreHome&action=index&idSite=7&period=day&date=yesterday#?idSite=7&period=day&date=yesterday&segment=&category=Dashboard_Dashboard&subcategory=1">Matomo</a>.</p>
+    <p>Last updated <time datetime="{{ now.Format " 2006-01-02" }}">{{ now.Format "2006-01-02" }}</time>. Live website
+        usage statistics are publicly accessible through <a class="dark-link"
+            href="https://matomo.wikimedia.se/index.php?module=CoreHome&action=index&idSite=7&period=day&date=yesterday#?idSite=7&period=day&date=yesterday&segment=&category=Dashboard_Dashboard&subcategory=1">Matomo</a>.
+    </p>
 
     <div class="grid number-container">
         <div class="number">
@@ -76,55 +79,63 @@
     </div>
 
     <h2>Coverage overview</h2>
-    <p>In the table below we have listed the types of organizations that are covered for each country. The amount of information about those organizations and contact points for them varies and is also improved over time.</p>
+    <p>In the table below we have listed the types of organizations that are covered for each country. The amount of
+        information about those organizations and contact points for them varies and is also improved over time.</p>
 
-    <table class="statistics-table">
-        <tr>
-            <th class="js-sort-none">Country</th>
-            <th class="js-sort-none">Contains</th>
-            <th class="js-sort-none">Organizations</th>
-            <th class="js-sort-none">Contact points</th>
-        <tr>
-        {{- range . -}}
-        {{- $social_cp_count := 0 -}}
-        {{- $other_cp := 0 -}}
-        {{- $country_org_count := 0 -}}
-        {{- $country := .safeName.String -}}
+    <table class="statistics-table js-sort-table">
+        <thead>
+            <tr>
+                <th>Country</th>
+                <th class="js-sort-none">Contains</th>
+                <th class="js-sort-number">Organizations</th>
+                <th class="js-sort-number">Contact points</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{- range . -}}
+            {{- $social_cp_count := 0 -}}
+            {{- $other_cp := 0 -}}
+            {{- $country_org_count := 0 -}}
+            {{- $country := .safeName.String -}}
             {{- $orgs := query (join "" "generators/" $country ".rq") -}}
             {{- $country_org_count = add (len $orgs) $country_org_count -}}
             {{- range $orgs -}}
-                {{ $social_cp_count = add (len (query "account-data.rq" .qid.String)) $social_cp_count }}
-                {{- $org_details := index (query "organization-optional.rq" .qid.String) 0 -}}
+            {{ $social_cp_count = add (len (query "account-data.rq" .qid.String)) $social_cp_count }}
+            {{- $org_details := index (query "organization-optional.rq" .qid.String) 0 -}}
 
-                    {{- if $org_details.email -}}
-                        {{- $other_cp = add1 $other_cp -}}
-                    {{- end -}}
-
-                    {{- if $org_details.website -}}
-                        {{- $other_cp = add1 $other_cp -}}
-                    {{- end -}}
-
-                    {{- if $org_details.phone -}}
-                        {{- $other_cp = add1 $other_cp -}}
-                    {{- end -}}
-
-                    {{- if $org_details.contactPage -}}
-                        {{- $other_cp = add1 $other_cp -}}
-                    {{- end -}}
-
-                    {{- if $org_details.citizensInitiatives -}}
-                        {{- $other_cp = add1 $other_cp -}}
-                    {{- end -}}
+            {{- if $org_details.email -}}
+            {{- $other_cp = add1 $other_cp -}}
             {{- end -}}
-            <td lang="{{ .description.Lang }}"><a href="../{{ .safeName }}/">{{ .name }}</a></td>
-            <td lang="{{ .description.Lang }}">{{ .description }}</td>
-            <td>{{ $country_org_count }}</td>
-            <td>{{ add $social_cp_count $other_cp }}</td>
-        </tr>
-        {{- end -}}
+
+            {{- if $org_details.website -}}
+            {{- $other_cp = add1 $other_cp -}}
+            {{- end -}}
+
+            {{- if $org_details.phone -}}
+            {{- $other_cp = add1 $other_cp -}}
+            {{- end -}}
+
+            {{- if $org_details.contactPage -}}
+            {{- $other_cp = add1 $other_cp -}}
+            {{- end -}}
+
+            {{- if $org_details.citizensInitiatives -}}
+            {{- $other_cp = add1 $other_cp -}}
+            {{- end -}}
+            {{- end -}}
+            <tr>
+                <td lang="{{ .description.Lang }}"><a href="../{{ .safeName }}/">{{ .name }}</a></td>
+                <td lang="{{ .description.Lang }}">{{ .description }}</td>
+                <td>{{ $country_org_count }}</td>
+                <td>{{ add $social_cp_count $other_cp }}</td>
+            </tr>
+            {{- end -}}
+        </tbody>
     </table>
 
 </main>
 {{ end }}
 
-{{ define "javascript" }}{{""}}{{ end }}
+{{ define "javascript" }}
+<script src="/thirdparty/sort-table/sort-table.js"></script>
+{{ end }}


### PR DESCRIPTION
## Description

Use the existing `sort-table.js` library (already used on country pages) to the
Coverage overview table on the statistics page. Country, Organizations, and Contact
points are now sortable by clicking the header; Contains stays static since it's free
text with no meaningful order.

The table was missing the `js-sort-table` class and had every header hardcoded as
`js-sort-none`. It also had a couple of markup bugs — a `<tr>` opened twice with no
closing tag, and no `<thead>`/`<tbody>` — which happened to render fine only because
browsers silently correct malformed tables. Fixed those as part of this change.

Verified the sort behavior locally in a standalone test page using the real
`sort-table.js` and the same table markup (screenshot attached). Wasn't able to get a
full `snowman build` to complete locally due to repeated 502/503s from the public WDQS
endpoint while fetching org data for the ~20k organizations this page queries — this is
unrelated to the change itself, which only touches static markup and JS wiring.

## Issue Reference

Fixes #664

## Checklist

- [x] I have tested the changes locally, and they work as expected.
- [x] The code follows the project's coding standards and conventions.
- [x] I have updated relevant documentation (if needed).
- [x] I have added unit tests or performed manual testing where necessary.

## Screenshots
<img width="1015" height="491" alt="image" src="https://github.com/user-attachments/assets/6b2309ce-1451-4aea-93f3-7f08c3681c4d" />

