### PR TITLE
feat filter by platform/set filter in URL

### DIFF
--- a/jargon.txt
+++ b/jargon.txt
@@ -201,6 +201,7 @@ platformLabel
 png
 portugal
 pre
+printf
 proactiveness
 pt
 publiccode

--- a/static/table-filter.js
+++ b/static/table-filter.js
@@ -1,0 +1,103 @@
+/**
+ * Filtering of the organization tables found on country and topic pages.
+ *
+ * Beside plain text matching the search supports a platform keyword:
+ *
+ *     platform:mastodon           organizations with a Mastodon account
+ *     platform:facebook,youtube   organizations with a Facebook or a YouTube account
+ *     housing platform:mastodon   a platform keyword combined with plain text
+ *
+ * The search box can also be populated from the URL using a query parameter,
+ * ie. /austria/?query=platform:mastodon,peertube
+ *
+ * The platforms of an organization are read from the data-platforms attribute
+ * set by the social icons component.
+ */
+(function () {
+    'use strict';
+
+    var filterInput = document.querySelector('#filter-input');
+    var tbody = document.querySelector('tbody');
+
+    if (!filterInput || !tbody) {
+        return;
+    }
+
+    // "PeerTube" as well as "Peer-Tube" becomes "peertube" so that platforms can
+    // be referred to without having to care about casing and punctuation
+    function normalize(value) {
+        return value.toLowerCase().replace(/[^a-z0-9]/g, '');
+    }
+
+    var rows = Array.from(tbody.rows).map(function (row) {
+        var platformsElm = row.querySelector('[data-platforms]');
+        var platforms = platformsElm ? platformsElm.dataset.platforms.split('|') : [];
+
+        return {
+            element: row,
+            text: row.textContent.toLowerCase(),
+            platforms: platforms.map(normalize).filter(Boolean)
+        };
+    });
+
+    // splits a query into its plain text part and one list of platforms per
+    // platform keyword, ie. "housing platform:mastodon,peertube" becomes
+    // { text: 'housing', platformGroups: [['mastodon', 'peertube']] }
+    function parseQuery(query) {
+        var text = [];
+        var platformGroups = [];
+
+        query.trim().split(/\s+/).forEach(function (token) {
+            var keyword = /^platform:(.*)$/i.exec(token);
+
+            if (!keyword) {
+                text.push(token);
+                return;
+            }
+
+            var platforms = keyword[1].split(',').map(normalize).filter(Boolean);
+            if (platforms.length) {
+                platformGroups.push(platforms);
+            }
+        });
+
+        return { text: text.join(' ').toLowerCase(), platformGroups: platformGroups };
+    }
+
+    // every keyword has to match while the platforms of a single keyword are
+    // alternatives, platforms match on their beginning so that the table keeps
+    // up while a platform name is being typed
+    function matchesPlatforms(platforms, platformGroups) {
+        return platformGroups.every(function (group) {
+            return group.some(function (wanted) {
+                return platforms.some(function (platform) {
+                    return platform.startsWith(wanted);
+                });
+            });
+        });
+    }
+
+    function filter(query) {
+        var parsed = parseQuery(query);
+
+        rows.forEach(function (row) {
+            var matches = row.text.includes(parsed.text)
+                && matchesPlatforms(row.platforms, parsed.platformGroups);
+            row.element.style.display = matches ? '' : 'none';
+        });
+    }
+
+    var query = new URLSearchParams(window.location.search).get('query');
+    if (query !== null) {
+        filterInput.value = query;
+    }
+
+    filterInput.addEventListener('input', function (e) {
+        filter(e.target.value);
+    });
+
+    // the input may hold a value from the URL or one restored by the browser
+    if (filterInput.value) {
+        filter(filterInput.value);
+    }
+})();

--- a/templates/components/social-icons.html
+++ b/templates/components/social-icons.html
@@ -3,7 +3,11 @@
 
 {{- $preview_count := 0 -}}
 {{- if or (len $socialAccounts) $details.website -}}
-<ul>
+{{- /* all platforms of the organization, pipe separated, used by the client side platform: filter */ -}}
+{{- $platforms := "" -}}
+{{- if $details.website -}}{{- $platforms = "Website" -}}{{- end -}}
+{{- range $socialAccounts -}}{{- $platforms = printf "%s|%s" $platforms .platformLabel.String -}}{{- end -}}
+<ul data-platforms="{{ $platforms }}">
     {{- if $details.website -}}
         <li><a rel="nofollow" title="Website" href="{{ $details.website }}"><img loading="lazy" width="20" height="20" aria-hidden="true" src="/social-icons/website.svg" /></a></li>
     {{- end -}}

--- a/templates/country-page.html
+++ b/templates/country-page.html
@@ -102,16 +102,7 @@ Array.from(dataTable.children[1].children).forEach((row, index) => {
 
 const downloadElm = document.querySelector('#download');
 downloadElm.href = window.URL.createObjectURL(new Blob([tsv], { type: 'text/tsv' }));
-
-var filterInput = document.querySelector('#filter-input');
-var tbody = document.querySelector('tbody');
-filterInput.addEventListener('input', function(e) {
-    Array.from(tbody.rows).forEach(function(row) {
-        var textContent = row.textContent.toLowerCase();
-        var filter = e.target.value.toLowerCase();
-        row.style.display = textContent.includes(filter) ? '' : 'none';
-    });
-});
 </script>
+<script src="/table-filter.js"></script>
 <script src="/thirdparty/sort-table/sort-table.js"></script>
 {{ end }}


### PR DESCRIPTION
# Description

This makes it possibly to filter lists by platform. One can now filter platforms by typing: `platform:mastodon,peertube` in the search box and can set such filters with the URL as well https://www.govdirectory.org/austria/?query=platform:mastodon,peertube

These filters can also be combined with other filters such as regular type searches(see screenshot).

## Issue Reference

Fixes #64

## Checklist

Please **ensure** the following before submitting the PR:

- [x] I have **tested** the changes locally, and they work as expected.
- [x] The code follows the project's coding standards and conventions.
- [ ] I have **updated relevant documentation** (if needed).
- [ ] I have added unit **tests** or performed manual testing where necessary.

## Screenshots (applicable to user interface changes)

<!-- Attach screenshots if relevant. -->

<img width="2880" height="1484" alt="Screenshot 2026-08-21 at 15-27-05 Sweden" src="https://github.com/user-attachments/assets/e45c4ed0-69fb-4aa9-9742-ff1d42fcb0e5" />
